### PR TITLE
Add WebSocket streaming for real-time responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,17 @@ logs/*
 src/main/webapp/static/*
 !src/main/webapp/static/.gitkeep
 
+# Test scripts and logs (setup helpers)
+test_setup.sh
+test_api.py
+test_websocket.py
+test_websocket_simple.py
+test_streaming_direct.py
+websocket_demo.html
+api.log
+websocket_test.log
+server.log
+
 # Eclipse project files
 .settings
 .classpath

--- a/chatbot-core/api/routes/chatbot.py
+++ b/chatbot-core/api/routes/chatbot.py
@@ -6,19 +6,20 @@ This module acts as a "controller" connecting the HTTP layer to
 the chat service logic.
 """
 
-from fastapi import APIRouter, HTTPException, Response, status
+from fastapi import APIRouter, HTTPException, Response, status, WebSocket, WebSocketDisconnect
 from api.models.schemas import (
     ChatRequest,
     ChatResponse,
     SessionResponse,
     DeleteResponse
 )
-from api.services.chat_service import get_chatbot_reply
+from api.services.chat_service import get_chatbot_reply, get_chatbot_reply_stream
 from api.services.memory import (
     init_session,
     delete_session,
     session_exists
 )
+import json
 
 router = APIRouter()
 
@@ -59,6 +60,44 @@ def chatbot_reply(session_id: str, request: ChatRequest):
         raise HTTPException(status_code=404, detail="Session not found.")
 
     return get_chatbot_reply(session_id, request.message)
+
+
+@router.websocket("/sessions/{session_id}/stream")
+async def chatbot_stream(websocket: WebSocket, session_id: str):
+    """
+    WebSocket endpoint for real-time token streaming.
+    
+    Args:
+        websocket (WebSocket): The WebSocket connection.
+        session_id (str): The ID of the session.
+    """
+    await websocket.accept()
+    
+    if not session_exists(session_id):
+        await websocket.send_text(json.dumps({"error": "Session not found"}))
+        await websocket.close()
+        return
+    
+    try:
+        while True:
+            data = await websocket.receive_text()
+            message_data = json.loads(data)
+            user_message = message_data.get("message", "")
+            
+            if not user_message:
+                continue
+                
+            # Stream response token by token
+            async for token in get_chatbot_reply_stream(session_id, user_message):
+                await websocket.send_text(json.dumps({"token": token}))
+            
+            # Send end marker
+            await websocket.send_text(json.dumps({"end": True}))
+            
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        await websocket.send_text(json.dumps({"error": str(e)}))
 
 
 @router.delete("/sessions/{session_id}", response_model=DeleteResponse)


### PR DESCRIPTION
### Add WebSocket streaming for real-time responses

#### Description
This pull request introduces WebSocket streaming functionality to the AI Chatbot plugin. The new feature enables token-by-token streaming of responses, improving responsiveness and user experience. This is particularly beneficial for local LLM setups, as it allows real-time output rendering in the frontend.

#### Changes Made
1. **Backend Updates**:
   - Added WebSocket endpoint `/sessions/{session_id}/stream` in `chatbot-core/api/routes/chatbot.py`.
   - Implemented token-by-token streaming in `chatbot-core/api/models/llama_cpp_provider.py` and `chatbot-core/api/services/chat_service.py`.

2. **Frontend Demo**:
   - Created `websocket_demo.html` to showcase real-time streaming in a simple chat interface.

3. **Test Scripts**:
   - Added test scripts (`test_websocket_simple.py`, `test_streaming_direct.py`) to verify WebSocket functionality.

4. **Updated `.gitignore`**:
   - Excluded test scripts, logs, and demo files from being committed to the repository.

#### Testing Done
- Verified WebSocket connection and token streaming using test scripts.
- Tested session creation and token-by-token response generation.
- Confirmed backward compatibility with existing REST API endpoints.

#### Benefits
- **Improved UX**: Real-time responses enhance user experience.
- **Backward Compatibility**: REST API remains unchanged.
- **Extensibility**: WebSocket streaming can be integrated into the Jenkins plugin frontend.
