### PR TITLE
fix(crawler): convert recursive crawl to iterative stack-based DFS

### DIFF
--- a/chatbot-core/data/collection/docs_crawler.py
+++ b/chatbot-core/data/collection/docs_crawler.py
@@ -64,14 +64,14 @@ def is_valid_url(url):
 
 def extract_page_content_container(soup):
     """Extract main content from the page.
-    
+
     Developer docs use col-8, non-developer docs use col-lg-9.
     Falls back to container if neither is found.
     """
     content_div = (
-        soup.find("div", class_="col-8") or 
-        soup.find("div", class_="col-lg-9") or
-        soup.find("div", class_="container")
+        soup.find("div", class_="col-8")
+        or soup.find("div", class_="col-lg-9")
+        or soup.find("div", class_="container")
     )
     if content_div:
         return str(content_div)


### PR DESCRIPTION
## Problem

The `crawl()` function in `docs_crawler.py` uses recursion, which hits Python's default limit (~1000) on deep Jenkins doc structures. Running with `sys.setrecursionlimit(50)` confirms the crash.

Fixes #60

## Solution

Switched from recursion to an explicit stack-based DFS. Same traversal order, no depth limit.

### What changed:
- **Iterative loop** — `while stack:` + `stack.pop()` instead of recursive calls
- **`reversed(links)`** — Stack is LIFO, so we push in reverse to pop in original order (thanks @cnu1812 for catching this)
- **Rate limiting** — `time.sleep(0.5)` placed *before* `requests.get()`, not at loop start. This way we skip duplicates fast without wasting time sleeping on URLs we'll discard anyway
- **`normalize_url()` helper** — Applied before stack push to catch `example.com` vs `example.com/` duplicates early

### Why stack over queue?
Queue would change traversal to BFS, which could affect `jenkins_docs.json` ordering. Downstream pipelines might rely on parent-before-child ordering, so I kept DFS to be safe.

## Testing

```bash
# Add to start_crawl() to trigger crash quickly:
import sys; sys.setrecursionlimit(50)

# Before: RecursionError
# After: Completes successfully
```

## Checklist

- [x] Preserves original DFS traversal order
- [x] Single URL failure doesn't break entire crawl
- [x] Rate limiting only on actual network calls
- [x] No new dependencies

---

Thanks to @pareshjoshij for the original report and rate limiting suggestion, and @cnu1812 for the thorough review on DFS order and sleep placement.