### PR TITLE
Fix frontend crash by aligning React root with index.html

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Chatbot } from "./components/Chatbot";
 
-const footerRoot = document.getElementById("chatbot-root")!;
+const footerRoot = document.getElementById("root")!;
 
 createRoot(footerRoot).render(
   <StrictMode>


### PR DESCRIPTION
Fixes #93

This PR fixes a frontend startup crash caused by a mismatch between
the root element defined in `index.html` and the element used in
`frontend/src/main.tsx`.

No other behavior is changed.
