### PR TITLE
Fix requirements.txt for macOS compatibility

### DIFF
--- a/chatbot-core/requirements.txt
+++ b/chatbot-core/requirements.txt
@@ -37,25 +37,25 @@ tokenizers==0.21.1
 torch==2.7.1
 torchaudio==2.7.1
 torchvision==0.22.1
-triton==3.3.1
+triton==3.3.1; sys_platform == 'linux'
 
 # =========================
 # NVIDIA CUDA (GPU-only, Python <3.13)
 # =========================
-nvidia-cublas-cu12==12.6.4.1
-nvidia-cuda-cupti-cu12==12.6.80
-nvidia-cuda-nvrtc-cu12==12.6.77
-nvidia-cuda-runtime-cu12==12.6.77
-nvidia-cudnn-cu12==9.5.1.17
-nvidia-cufft-cu12==11.3.0.4
-nvidia-cufile-cu12==1.11.1.6; python_version < "3.13"
-nvidia-curand-cu12==10.3.7.77
-nvidia-cusolver-cu12==11.7.1.2
-nvidia-cusparse-cu12==12.5.4.2
-nvidia-cusparselt-cu12==0.6.3
-nvidia-nccl-cu12==2.26.2
-nvidia-nvjitlink-cu12==12.6.85
-nvidia-nvtx-cu12==12.6.77
+nvidia-cublas-cu12==12.6.4.1; sys_platform != 'darwin'
+nvidia-cuda-cupti-cu12==12.6.80; sys_platform != 'darwin'
+nvidia-cuda-nvrtc-cu12==12.6.77; sys_platform != 'darwin'
+nvidia-cuda-runtime-cu12==12.6.77; sys_platform != 'darwin'
+nvidia-cudnn-cu12==9.5.1.17; sys_platform != 'darwin'
+nvidia-cufft-cu12==11.3.0.4; sys_platform != 'darwin'
+nvidia-cufile-cu12==1.11.1.6; python_version < "3.13" and sys_platform != 'darwin'
+nvidia-curand-cu12==10.3.7.77; sys_platform != 'darwin'
+nvidia-cusolver-cu12==11.7.1.2; sys_platform != 'darwin'
+nvidia-cusparse-cu12==12.5.4.2; sys_platform != 'darwin'
+nvidia-cusparselt-cu12==0.6.3; sys_platform != 'darwin'
+nvidia-nccl-cu12==2.26.2; sys_platform != 'darwin'
+nvidia-nvjitlink-cu12==12.6.85; sys_platform != 'darwin'
+nvidia-nvtx-cu12==12.6.77; sys_platform != 'darwin'
 
 # =========================
 # Vector Store & Retrieval


### PR DESCRIPTION
Exclude NVIDIA packages on macOS using environment markers.

I ran into an issue when trying to run the project as per docs/setup.md on my M1 machine. Turns out that the requirements.txt file was attempting to install `triton` and cuda packages not available on Apple Silicon. So, I added environment markers to include them only when the `sys_platform` is not `darwin`

### Testing done
Built the project successfully. 
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
