### PR TITLE
Fix: Offload blocking session retrieval to a thread pool

### DIFF
--- a/chatbot-core/api/services/chat_service.py
+++ b/chatbot-core/api/services/chat_service.py
@@ -16,7 +16,7 @@ from api.prompts.prompts import (
     RETRIEVER_AGENT_PROMPT,
     SPLIT_QUERY_PROMPT,
 )
-from api.services.memory import get_session
+from api.services.memory import get_session, get_session_async
 from api.services.file_service import format_file_context
 from api.tools.tools import TOOL_REGISTRY
 from api.tools.utils import (
@@ -462,7 +462,7 @@ async def get_chatbot_reply_stream(
     logger.info("Streaming message from session '%s'", session_id)
     logger.info("Handling user query: %s", user_input)
 
-    memory = get_session(session_id)
+    memory = await get_session_async(session_id)
     if memory is None:
         raise RuntimeError(
             f"Session '{session_id}' not found in memory store.")

--- a/chatbot-core/api/services/memory.py
+++ b/chatbot-core/api/services/memory.py
@@ -6,6 +6,7 @@ Provides utility functions for session lifecycle.
 import uuid
 from datetime import datetime, timedelta
 from threading import Lock
+import asyncio
 from langchain.memory import ConversationBufferMemory
 from api.config.loader import CONFIG
 from api.services.sessionmanager import(
@@ -76,6 +77,13 @@ def get_session(session_id: str) -> ConversationBufferMemory | None:
         }
 
         return memory
+
+
+async def get_session_async(session_id: str) -> ConversationBufferMemory | None:
+    """
+    Asynchronous version of get_session that offloads blocking I/O to a thread pool.
+    """
+    return await asyncio.to_thread(get_session, session_id)
 
 
 def persist_session(session_id: str)-> None:


### PR DESCRIPTION
## Summary

This PR addresses a critical performance bottleneck where the synchronous `get_session.py` call was blocking the `asyncio` event loop during chat streaming. As a result, the server could become unresponsive to concurrent requests (e.g., health checks and other users) while sessions were being loaded from disk.

By introducing a thread-safe asynchronous wrapper, the server remains responsive under concurrent load without introducing any breaking changes.


## The Problem with Previous PR

The other proposed solution attempted to resolve this issue by converting `get_chatbot_reply` into an `async def` function.

### Why that approach was incorrect

- **Breaking Changes**  
  Changing the core `get_chatbot_reply` function to asynchronous would break all existing synchronous callers across the codebase.

- **Scope Creep**  
  The async bottleneck was limited to the streaming path, but this approach modified unrelated core logic, increasing the risk of regressions.

- **Redundant Imports**  
  Previous attempts included duplicate `asyncio` imports and lacked a clear separation of concerns.



## Solution

This PR implements a targeted, non-breaking fix that preserves the existing synchronous API while specifically unblocking the async streaming path.

### Key Changes

- **Non-blocking Wrapper**  
  Added `get_session_async` in `memory.py`, leveraging `asyncio.to_thread` to safely offload blocking I/O without modifying existing synchronous function signatures.

- **Streaming Optimization**  
  Updated only `get_chatbot_reply_stream` in `chat_service.py` to use the asynchronous session retriever, ensuring the event loop remains responsive during streaming.


