### PR TITLE
Fix React mount point ID mismatch

### DIFF
--- a/src/main/resources/io/jenkins/plugins/chatbot/ChatbotGlobalDecorator/footer.jelly
+++ b/src/main/resources/io/jenkins/plugins/chatbot/ChatbotGlobalDecorator/footer.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-  <div id="chatbot-root"></div>
+  <div id="root"></div>
   <script type="module" src="${rootURL}/plugin/resources-ai-chatbot/static/assets/index.js"></script>
 </j:jelly>


### PR DESCRIPTION
## Description
Fixes the React application mounting failure by aligning the DOM element ID between the Jelly template and React entry point.

## Changes
- Changed `<div id="chatbot-root">` to `<div id="root">` in `footer.jelly`
- This matches the element ID that `main.tsx` expects: `document.getElementById("root")`

## Problem
The chatbot React app was failing to mount because:
- `footer.jelly` created: `<div id="chatbot-root"></div>`
- `main.tsx` looked for: `document.getElementById("root")`

This mismatch caused a React error #299 and prevented the chatbot UI from rendering.

## Testing Done
- [x] Built frontend: `npm run build`
- [x] Ran Jenkins locally: `mvn hpi:run`
- [x] Verified chatbot UI now renders without React errors in browser console
- [x] Confirmed the chatbot icon appears in Jenkins UI

### Manual Testing
Tested on Windows 11 with:
- Jenkins 2.504.3 (development mode)
- Node.js v18.20.8
- Java JDK 17

**Before fix:** React mounting error in console, no chatbot UI visible
**After fix:** Chatbot renders successfully

## Submitter Checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - no automated tests exist for this UI component yet
- [x] Ensure the changeset is minimal and focused

Fixes #110
