### PR TITLE
Fix typo error message

### DIFF
--- a/frontend/src/utils/callChatbotApi.ts
+++ b/frontend/src/utils/callChatbotApi.ts
@@ -33,7 +33,7 @@ export const callChatbotApi = async <T>(
   } catch (error: unknown) {
     if (error instanceof DOMException && error.name == "AbortError") {
       console.error(
-        `API request to ${endpoint} timed out aftr ${timeoutMs}ms.`,
+        `API request to ${endpoint} timed out after ${timeoutMs}ms.`,
       );
     } else {
       console.error(`API error calling ${endpoint}:`, error);


### PR DESCRIPTION
## Description
Fixes a typo in the timeout error message.

## Changes
- Changed "aftr" to "after" in `frontend/src/utils/callChatbotApi.ts` line 34

## Related Issue
Fixes #121 

## Testing
- No functional changes
- Error message now displays correctly when API timeout occurs
