### PR TITLE
Handle QueryType case insensitively

### DIFF
--- a/chatbot-core/api/services/chat_service.py
+++ b/chatbot-core/api/services/chat_service.py
@@ -487,10 +487,11 @@ async def get_chatbot_reply_stream(
 def _extract_query_type(response: str) -> str:
     """
     Extracts 'SIMPLE' or 'MULTI' from the response if present, else returns an empty string.
+    The search is case-insensitive, and the result is returned in uppercase.
     """
-    match = re.search(r"\b(SIMPLE|MULTI)\b", response)
+    match = re.search(r"\b(SIMPLE|MULTI)\b", response, re.IGNORECASE)
     if match:
-        return match.group(1)
+        return match.group(1).upper()
 
     return ""
 
@@ -498,8 +499,9 @@ def _extract_query_type(response: str) -> str:
 def _extract_relevance_score(response: str) -> str:
     """
     Extracts relevance score (0 or 1) from a response labeled with 'Label: N'; defaults to 0.
+    The search is case-insensitive.
     """
-    match = re.search(r"Label:\s*([01])", response)
+    match = re.search(r"Label:\s*([01])", response, re.IGNORECASE)
     if match:
         relevance_score = int(match.group(1))
     else:


### PR DESCRIPTION
Description
This change makes QueryType handling case-insensitive in chat_service.py.
Previously, values such as Simple or Multi were rejected because only uppercase values were accepted, causing incorrect routing.
The input is now normalized before validation so equivalent values are handled consistently.
Resolves #130

Testing done:
Not tested manually.

Submitter checklist:
- [x] Opening from a feature branch (fix-QueryType-case)
- [x] PR title reflects the change
- [x] Change described clearly
- [x] Related issue: #130 
- [ ] Related pull requests
- [ ] Tests added (not added)