### PR TITLE
Implement CI lifecycle jobs for chatbot: install, start and uninstall

### DIFF
--- a/Jenkinsfile.installer
+++ b/Jenkinsfile.installer
@@ -1,0 +1,51 @@
+pipeline{
+    agent any
+        
+
+    options {
+        timestamps()
+        disableConcurrentBuilds()
+    }
+
+    tools{
+        nodejs 'NodeJS 20'
+    }
+
+    stages {
+        stage('Clone'){
+          steps {
+              echo 'Cloning repository...'
+              sh "
+                git clone --branch main --single-branch https://github.com/your-repo/resources-chatbot-ai-plugin.git"
+          }
+        }
+
+        stage('Install') {
+            steps {
+
+                echo 'Running installation steps...'
+                dir('resources-ai-chatbot-plugin') {
+                    sh '''
+                     set -e
+                     
+                     make setup-backend
+                     cp -r initgroovy/ChatbotWatch.groovy $JENKINS_HOME/init.groovy.d
+                     cp -r initgroovy/ChatbotStart.groovy $JENKINS_HOME/init.groovy.d
+                     
+
+                '''
+                }
+
+            }
+        }
+    }
+
+    post {
+        success {
+            echo 'Installation completed successfully.'
+        }
+        failure {
+            echo 'Installation failed.'
+        }
+    }
+}

--- a/Jenkinsfile.start
+++ b/Jenkinsfile.start
@@ -1,0 +1,16 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Start') {
+            steps {
+                dir('resources-ai-chatbot-plugin') {
+                    sh '''
+                    echo 'Starting chatbot...'
+                    make run-api
+                    '''
+                }
+            }
+        }
+    }
+}

--- a/Jenkinsfile.uninstall
+++ b/Jenkinsfile.uninstall
@@ -1,0 +1,31 @@
+pipeline{
+    agent any
+    options {
+        timestamps()
+        disableConcurrentBuilds()
+    }
+        
+    stages{
+        stage('Uninstall'){
+            steps{
+
+                dir('resources-ai-chatbot-plugin') {
+                    sh '''
+                    echo 'Removing chatbot...'
+                    set -e
+                    make uninstall'''
+                }
+                
+            }
+        }
+        
+    }
+    post {
+        success {
+            echo 'Chatbot uninstalled successfully.'
+        }
+        failure {
+            echo 'Chatbot uninstallation failed.'
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all api setup-backend build-frontend test run-data-pipeline clean
 
+
 BACKEND_SHELL = cd chatbot-core && . ./venv/bin/activate
 
 ifeq ($(IS_CPU_REQ),1)
@@ -8,7 +9,7 @@ else
 	REQUIREMENTS=requirements.txt
 endif
 
-all: build-frontend setup-backend run-api
+all: build-frontend run-api
 
 setup-backend:
 	@if [ ! -d chatbot-core/venv ]; then \
@@ -16,19 +17,29 @@ setup-backend:
 		python3 -m venv venv && \
 		. venv/bin/activate && \
 		pip install -r $(REQUIREMENTS); \
+		pip install python-multipart;\
 	else \
 		echo "Backend already set up. Skipping virtualenv creation and dependencies installation."; \
 	fi
 
 build-frontend:
 	@cd frontend && \
-	npm install && \
+	 npm install && \
+	 npm run build
+
+install-frontend:
+	@cd frontend && \
+	npm install
+
+run-frontend:
+	@cd frontend && \
 	npm run build
+
 
 # API
 
 run-api:
-	@$(BACKEND_SHELL) && PYTHONPATH=$$(pwd) uvicorn api.main:app --reload
+	@$(BACKEND_SHELL) && PYTHONPATH=$(pwd) uvicorn api.main:app --reload
 
 api: setup-backend run-api
 
@@ -146,3 +157,10 @@ run-data-pipeline:
 
 clean:
 	@rm -rf chatbot-core/venv frontend/node_modules
+
+uninstall:
+	@rm -rf chatbot-core/venv
+	@rm -rf frontend/node_modules
+	@rm -rf frontend/build
+	@rm -rf logs
+	@rm -rf initgroovy/chatbot-start.groovy

--- a/initgroovy/ChatbotStart.groovy
+++ b/initgroovy/ChatbotStart.groovy
@@ -1,0 +1,14 @@
+import hudson.security.ACL
+import jenkins.model.Jenkins
+
+ACL.impersonate(ACL.SYSTEM)
+
+def jobName = "Chatbot-start"
+def job = Jenkins.instance.getItemByFullName(jobName)
+
+if (job == null) {
+    println "[Chatbot Watcher] ERROR: Job not found: ${jobName}"
+    return
+}
+
+job.scheduleBuild2(0)

--- a/initgroovy/ChatbotWatch.groovy
+++ b/initgroovy/ChatbotWatch.groovy
@@ -1,0 +1,111 @@
+import jenkins.model.Jenkins
+import jenkins.util.Timer
+import hudson.security.ACL
+import java.nio.file.*
+import java.util.concurrent.TimeUnit
+import groovy.transform.Field
+
+import static java.nio.file.StandardWatchEventKinds.*
+
+
+@Field String PLUGIN_JPI = "resources-ai-chatbot-plugin.jpi"
+@Field String PLUGIN_HPI = "resources-ai-chatbot-plugin.hpi"
+@Field String UNINSTALL_JOB = "Chatbot-uninstall"
+
+@Field File JENKINS_HOME = Jenkins.instance.rootDir
+@Field File PLUGINS_DIR = new File(JENKINS_HOME, "plugins")
+
+@Field File INSTALL_MARKER = new File(JENKINS_HOME, "chatbot-install.mkr")
+
+
+@Field volatile boolean uninstallTriggered = false
+
+println "[Chatbot Watcher] Jenkins starting. Scheduling watcher startup…"
+
+
+Timer.get().schedule({
+
+    println "[Chatbot Watcher] Startup delay elapsed. Starting plugin watcher."
+    startWatcherSafely()
+
+}, 9, TimeUnit.SECONDS)  
+
+def startWatcherSafely() {
+
+    if (!PLUGINS_DIR.exists()) {
+        println "[Chatbot Watcher] Plugins directory not found. Aborting watcher."
+        return
+    }
+
+    WatchService watchService = FileSystems.getDefault().newWatchService()
+
+    PLUGINS_DIR.toPath().register(
+        watchService,
+        ENTRY_CREATE,
+        ENTRY_MODIFY,
+        ENTRY_DELETE
+    )
+
+    println "[Chatbot Watcher] Watching directory: ${PLUGINS_DIR.absolutePath}"
+
+    while (true) {
+        WatchKey key = watchService.take()
+        println "[Chatbot Watcher] RAW EVENT RECEIVED"
+        key.pollEvents().each { event ->
+
+            def changed = event.context().toString()
+            println "[Chatbot Watcher] Event: ${event.kind()} → ${changed}"
+
+            if (changed.startsWith("resources-ai-chatbot")) {
+            verifyPluginRemoval()
+            }
+        }
+        key.reset()
+    }
+}
+
+def verifyPluginRemoval() {
+
+    if (uninstallTriggered) {
+        return
+    }
+
+    sleep(1500)
+
+    File jpi = new File(PLUGINS_DIR, PLUGIN_JPI)
+    File hpi = new File(PLUGINS_DIR, PLUGIN_HPI)
+
+    if (!jpi.exists() && !hpi.exists() && INSTALL_MARKER.exists()) {
+
+        uninstallTriggered = true
+        println "[Chatbot Watcher] Plugin confirmed removed."
+
+        triggerUninstallJob()
+        deleteMarkers()
+    }
+}
+
+def triggerUninstallJob() {
+
+    println "[Chatbot Watcher] Triggering uninstall job: ${UNINSTALL_JOB}"
+
+    ACL.impersonate(ACL.SYSTEM)
+
+    def job = Jenkins.instance.getItemByFullName(UNINSTALL_JOB)
+
+    if (job == null) {
+        println "[Chatbot Watcher] ERROR: Job not found: ${UNINSTALL_JOB}"
+        return
+    }
+
+    job.scheduleBuild2(0)
+}
+
+def deleteMarkers() {
+
+    if (INSTALL_MARKER.exists()) {
+        INSTALL_MARKER.delete()
+        println "[Chatbot Watcher] Install marker deleted."
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/chatbot/ChatbotPluginLifecycle.java
+++ b/src/main/java/io/jenkins/plugins/chatbot/ChatbotPluginLifecycle.java
@@ -1,0 +1,103 @@
+package io.jenkins.plugins.chatbot;
+
+import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import hudson.model.Job;
+import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+import jenkins.util.Timer;
+
+@Extension
+public class ChatbotPluginLifecycle extends RunListener<Run<?, ?>> {
+
+    private static final Logger LOGGER = Logger.getLogger(ChatbotPluginLifecycle.class.getName());
+
+    private static final String INSTALL_JOB = "Chatbot-install";
+    private static final String INSTALL_MARKER_FILE = "chatbot-install.mkr";
+
+    private static final AtomicBoolean BOOTSTRAP_TRIGGERED = new AtomicBoolean(false);
+
+    @Initializer(after = InitMilestone.PLUGINS_STARTED)
+    public static void onJenkinsStartup() {
+        LOGGER.info("Chatbot plugin detected. Scheduling bootstrap.");
+
+        Timer.get().submit(() -> {
+            try {
+                bootstrap();
+            } catch (Throwable t) {
+                LOGGER.severe("Chatbot bootstrap failed: " + t.getMessage());
+            }
+        });
+    }
+
+    private static void bootstrap() {
+        if (!BOOTSTRAP_TRIGGERED.compareAndSet(false, true)) {
+            return;
+        }
+
+        Jenkins jenkins = Jenkins.get();
+        File install_marker = new File(jenkins.getRootDir(), INSTALL_MARKER_FILE);
+
+        if (!install_marker.exists()) {
+            triggerJob(INSTALL_JOB);
+            return;
+        } else {
+            LOGGER.info("Chatbot already running. No action needed.");
+        }
+    }
+
+    private static void triggerJob(String jobName) {
+        Job<?, ?> job = Jenkins.get().getItemByFullName(jobName, Job.class);
+        if (job == null) {
+            LOGGER.warning("Job not found: " + jobName);
+            return;
+        }
+
+        LOGGER.info("Triggering job: " + jobName);
+        Queue.Task task = (Queue.Task) job;
+        Jenkins.get().getQueue().schedule(task, 0);
+    }
+
+    @Override
+    public void onCompleted(Run<?, ?> run, TaskListener listener) {
+        String jobName = run.getParent().getFullName();
+        Result result = run.getResult();
+
+        if (INSTALL_JOB.equals(jobName)) {
+            handleInstallResult(result);
+        }
+    }
+
+    private void handleInstallResult(Result result) {
+        if (result == Result.SUCCESS) {
+            LOGGER.info("Chatbot installed successfully.");
+            createMarkerFile(INSTALL_MARKER_FILE);
+        } else {
+            LOGGER.warning("Chatbot installation failed.");
+        }
+    }
+
+    private void createMarkerFile(String markerName) {
+        try {
+            File marker = new File(Jenkins.get().getRootDir(), markerName);
+
+            if (marker.createNewFile()) {
+                LOGGER.info(markerName + " file created.");
+            } else {
+                LOGGER.info(markerName + " file already exists.");
+            }
+
+        } catch (IOException e) {
+            LOGGER.warning("Failed to create marker file: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/chatbot/ChatbotPluginStop.java
+++ b/src/main/java/io/jenkins/plugins/chatbot/ChatbotPluginStop.java
@@ -1,0 +1,37 @@
+package io.jenkins.plugins.chatbot;
+
+import hudson.Plugin;
+import hudson.model.Executor;
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.Run;
+import java.util.logging.Logger;
+import jenkins.model.Jenkins;
+
+public class ChatbotPluginStop extends Plugin {
+
+    private static final Logger LOGGER = Logger.getLogger(ChatbotPluginStop.class.getName());
+
+    @Override
+    public void stop() throws Exception {
+
+        Job<?, ?> interruptJob = Jenkins.get().getItemByFullName("Chatbot-start", Job.class);
+
+        try {
+            if (interruptJob != null) {
+                Run<?, ?> build = interruptJob.getLastBuild();
+                if (build != null && build.isBuilding()) {
+                    Executor executor = build.getExecutor();
+                    if (executor != null) {
+                        executor.interrupt(Result.ABORTED);
+                        LOGGER.info("Interrupting running Chatbot-start job.");
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.severe("Error while trying to interrupt Chatbot-start job: " + e.getMessage());
+        }
+
+        super.stop();
+    }
+}


### PR DESCRIPTION
### Description
**Issue**:Current `.hpi` package does not triggers lifecycle jobs that results into failure of application setup automatically and requires manual intervention.

**Solution**:Introduce chatbot lifecycle CI jobs (install, start and uninstall) and ensure they operate on a consistent working directory so stateful steps (watcher + runtime files) behave predictably.

Fixes #53

---

### Testing done

* Ran install → start → uninstall sequence on Jenkins controller
* Verified all jobs execute against the same directory
* Confirmed watcher scripts detect expected files and lifecycle flow completes
* Re-ran jobs multiple times to ensure stability

No automated tests added since this change affects Jenkins job orchestration rather than application runtime code.


### Help wanted: Single source of truth workspace in Jenkins Pipeline

Current implementation of  chatbot lifecycle CI (install → start → uninstall) relies on a single working directory as the source of truth for runtime state.

Jenkins sometimes creates multiple isolated  workspaces which causes different steps to operate on different temporary workspaces and breaks the lifecycle flow.

Looking for a clean Jenkins-native way to ensure all related jobs always use one consistent workspace instead of multiple temporary ones.
