### PR TITLE
docs: fix typos, broken code fence, and incorrect path separators

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,8 @@ Below is a brief explanation of the key subdirectories:
   - `utils/`: Contains utils for the chatbot-core directory(e.g. logger).
   - `rag/`: Core logic of the RAG
     - `embedding/`: Scripts to embed the chunks.
-    - `vectorestore/`: Scripts to store the embeddings into a vector database.
-    - `retrieval/`: Scripts to perform the semantic research across the vectore database.
+    - `vectorstore/`: Scripts to store the embeddings into a vector database.
+    - `retrieval/`: Scripts to perform the semantic research across the vector database.
   - `api/`: FastAPI application that exposes the chatbot via a REST API.
     - `main.py`: Entry point to run the FastAPI app.
     - `routes/`: Defines the HTTP endpoints.
@@ -29,7 +29,7 @@ Below is a brief explanation of the key subdirectories:
     - `integration/`: Contains the integration tests and the related configuration.
   - `requirements.txt`: Python dependencies.
   - `requirements-cpu.txt`: Python dependencies for cpu only usage.
-- `docs/`: Developer documentation. Inside it mirros the codebase layout.
+- `docs/`: Developer documentation. Inside it mirrors the codebase layout.
 - `frontend/`: Directory for the frontend React application.
 
 ## Getting Started
@@ -51,7 +51,7 @@ The first thing we want to be able to do is running the whole data pipeline. The
 
 > **Note:** the collection of StackOverflow's data is not included; to include it you must follow [this](chatbot-core/data/collection.md).
 
-So starting from the identificatiion of the data sources(e.g. Jenkins Official Documentation) the data pipeline will collect it, process it, and finally store it in a vector database(FAISS) to later perform semantic search.
+So starting from the identification of the data sources(e.g. Jenkins Official Documentation) the data pipeline will collect it, process it, and finally store it in a vector database(FAISS) to later perform semantic search.
 
 To run the following pipeline you can use the `run-data-pipeline` target:
 ```bash

--- a/docs/chatbot-core/handling-query-flow.md
+++ b/docs/chatbot-core/handling-query-flow.md
@@ -22,7 +22,7 @@ flowchart TD
     J3 --> J4
 
     J2 --> |Relevant context| Z[.]
-    J2 --> |Medium/Low relveant context| I3[Reformulate query]
+    J2 --> |Medium/Low relevant context| I3[Reformulate query]
     I3 --> H
     J2 --> |Very Low relevant context| Z1[Avoid hallucination ; Answer you are not able to respond]
 

--- a/docs/frontend/frontend.md
+++ b/docs/frontend/frontend.md
@@ -23,7 +23,7 @@ The chatbot UI is built using the following technologies:
 
 ## Setup and Use
 > **Note**:  
-> It is encouraged to use the latest**Node.js LTS** (project built with Node 24).  
+> It is encouraged to use the latest **Node.js LTS** (project built with Node 24).  
 > Ensure `npm` is available in your environment.
 
 To build and run the frontend as part of the Jenkins plugin:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -111,12 +111,12 @@ make api
 6. **Download the Required Model**
     1. Create the model directory if it doesn't exist:
         ```bash
-        mkdir -p api\models\mistral
+        mkdir -p api/models/mistral
         ```
     2. Download the Mistral 7B Instruct model from Hugging Face:
         * Go to https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF
         * Download the file named `mistral-7b-instruct-v0.2.Q4_K_M.gguf`
-        * Place the downloaded file in `api\models\mistral\`
+        * Place the downloaded file in `api/models/mistral/`
 
 By default, the backend attempts to load the local GGUF model during
 startup. If the model file is missing, the server will fail to start.
@@ -269,13 +269,15 @@ dependencies that require native compilation (e.g. `llama-cpp-python`).
 `llama-cpp-python` requires a working C/C++ toolchain and CMake to build native extensions.
 
 **Solution**
+
 For Linux (Ubuntu/Debian):
 ```bash
 sudo apt install build-essential cmake
 pip install llama-cpp-python
+```
 
 For macOS:
 ```bash
 brew install cmake
-pip install llama-cpp-python    
+pip install llama-cpp-python
 ```


### PR DESCRIPTION
Fixes #182 

### Changes

**docs/README.md** — 4 typos fixed:
- `vectorestore` → `vectorstore`
- `vectore database` → `vector database`
- `mirros` → `mirrors`
- `identificatiion` → `identification`

**docs/setup.md** — 2 fixes:
- Unclosed code fence in troubleshooting section (Linux block ran into macOS block)
- Windows backslashes in Linux installation section (`api\models\mistral` → `api/models/mistral`)

**docs/chatbot-core/handling-query-flow.md** — 1 typo:
- `relveant` → `relevant` (in mermaid diagram)

**docs/frontend/frontend.md** — 1 formatting fix:
- Missing space before bold text (`latest**Node.js` → `latest **Node.js`)