### PR TITLE
test: expand prompt_builder unit tests for log_context, multi-turn hi…

### DIFF
--- a/chatbot-core/tests/unit/prompts/test_prompt_builder.py
+++ b/chatbot-core/tests/unit/prompts/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 from langchain.memory import ConversationBufferMemory
 from api.prompts.prompt_builder import build_prompt, SYSTEM_INSTRUCTION
+from api.prompts.prompts import LOG_ANALYSIS_INSTRUCTION
 
 
 def test_build_prompt_with_full_history_and_context():
@@ -75,6 +76,164 @@ def test_build_prompt_with_none_memory():
     assert history_section.strip() == ""
     assert context in context_section
     assert user_query in question_section
+
+def test_build_prompt_with_log_context_uses_log_analysis_instruction():
+    """Test that providing log_context switches to LOG_ANALYSIS_INSTRUCTION
+    and includes the 'User-Provided Log Data' section in the prompt."""
+    memory = ConversationBufferMemory(return_messages=True)
+    context = "Jenkins pipeline documentation."
+    user_query = "Why did my build fail?"
+    log_context = "ERROR: Build step 'Execute shell' marked build as failure"
+
+    prompt = build_prompt(user_query, context, memory, log_context=log_context)
+
+    # Should use LOG_ANALYSIS_INSTRUCTION, NOT SYSTEM_INSTRUCTION
+    assert LOG_ANALYSIS_INSTRUCTION.strip() in prompt
+    assert SYSTEM_INSTRUCTION.strip() not in prompt
+
+    # Log section must be present with the actual log data
+    assert "User-Provided Log Data:" in prompt
+    assert log_context in prompt
+
+    # Standard structural sections still present and in order
+    chat_idx, context_idx, question_idx, answer_idx = get_prompt_indexes(prompt)
+    assert chat_idx < context_idx < question_idx < answer_idx
+
+    # User query still appears correctly
+    _, _, question_section = get_prompt_sections(prompt)
+    assert user_query.strip() in question_section
+
+
+def test_build_prompt_with_log_context_and_history():
+    """Test the full combination: log_context + conversation history + context."""
+    memory = ConversationBufferMemory(return_messages=True)
+    memory.chat_memory.add_user_message("My build failed.") # pylint: disable=no-member
+    memory.chat_memory.add_ai_message("Can you share the logs?") # pylint: disable=no-member
+    context = "Check Jenkins console output for errors."
+    user_query = "Here are my logs, can you analyze?"
+    log_context = "java.lang.OutOfMemoryError: Java heap space"
+
+    prompt = build_prompt(user_query, context, memory, log_context=log_context)
+
+    # Uses log analysis instruction
+    assert LOG_ANALYSIS_INSTRUCTION.strip() in prompt
+    assert SYSTEM_INSTRUCTION.strip() not in prompt
+
+    # History is preserved
+    history_section, context_section, question_section = get_prompt_sections(prompt)
+    assert "User: My build failed." in history_section
+    assert "Jenkins Assistant: Can you share the logs?" in history_section
+
+    # Context and log data are both present
+    assert context in context_section
+    assert "User-Provided Log Data:" in prompt
+    assert log_context in prompt
+
+    # Question appears correctly
+    assert user_query.strip() in question_section
+
+
+def test_build_prompt_with_empty_string_log_context_uses_system_instruction():
+    """Test that an empty string log_context (falsy) does NOT trigger the
+    log analysis branch — should fall back to SYSTEM_INSTRUCTION."""
+    memory = ConversationBufferMemory(return_messages=True)
+    context = "Some context."
+    user_query = "How do I configure agents?"
+
+    prompt = build_prompt(user_query, context, memory, log_context="")
+
+    # Should use standard instruction since "" is falsy
+    assert SYSTEM_INSTRUCTION.strip() in prompt
+    assert LOG_ANALYSIS_INSTRUCTION.strip() not in prompt
+    assert "User-Provided Log Data:" not in prompt
+
+
+def test_build_prompt_with_none_log_context_uses_system_instruction():
+    """Test that log_context=None (the default) does NOT trigger the
+    log analysis branch."""
+    memory = ConversationBufferMemory(return_messages=True)
+    context = "Some context."
+    user_query = "How do I set up a pipeline?"
+
+    prompt = build_prompt(user_query, context, memory, log_context=None)
+
+    assert SYSTEM_INSTRUCTION.strip() in prompt
+    assert LOG_ANALYSIS_INSTRUCTION.strip() not in prompt
+    assert "User-Provided Log Data:" not in prompt
+
+def test_build_prompt_with_multiple_conversation_turns():
+    """Test that multiple rounds of user/assistant messages are all
+    captured in the Chat History section in the correct order."""
+    memory = ConversationBufferMemory(return_messages=True)
+    memory.chat_memory.add_user_message("What is a Jenkinsfile?") # pylint: disable=no-member
+    memory.chat_memory.add_ai_message("A Jenkinsfile defines your pipeline.") # pylint: disable=no-member
+    memory.chat_memory.add_user_message("Can I use it with GitHub?") # pylint: disable=no-member
+    memory.chat_memory.add_ai_message("Yes, you can integrate it with GitHub.") # pylint: disable=no-member
+    context = "Jenkinsfile supports declarative and scripted syntax."
+    user_query = "Show me an example."
+
+    prompt = build_prompt(user_query, context, memory)
+
+    history_section, _, _ = get_prompt_sections(prompt)
+
+    # All four messages must appear in history
+    assert "User: What is a Jenkinsfile?" in history_section
+    assert "Jenkins Assistant: A Jenkinsfile defines your pipeline." in history_section
+    assert "User: Can I use it with GitHub?" in history_section
+    assert "Jenkins Assistant: Yes, you can integrate it with GitHub." in history_section
+
+    # Order: first user message appears before second user message
+    first_user_pos = history_section.index("User: What is a Jenkinsfile?")
+    second_user_pos = history_section.index("User: Can I use it with GitHub?")
+    assert first_user_pos < second_user_pos
+
+
+def test_build_prompt_with_none_content_message():
+    """Test that a message with None content is handled gracefully
+    (the `msg.content or ''` guard in the source)."""
+    memory = ConversationBufferMemory(return_messages=True)
+    memory.chat_memory.add_user_message("Hello") # pylint: disable=no-member
+    # Simulate a None content message by directly manipulating memory
+    memory.chat_memory.messages[-1].content = None  # pylint: disable=no-member
+    context = "Jenkins docs."
+    user_query = "Test query"
+
+    prompt = build_prompt(user_query, context, memory)
+
+    history_section, _, _ = get_prompt_sections(prompt)
+    # Should show "User: " with empty content, not crash
+    assert "User: " in history_section
+
+
+def test_build_prompt_with_special_characters_in_query():
+    """Test that special characters (unicode, newlines) in the user query
+    are preserved correctly in the output prompt."""
+    memory = ConversationBufferMemory(return_messages=True)
+    context = "Jenkins configuration docs."
+    user_query = "  How do I use the 'pipeline' with \"quotes\" & <angle> brackets?\n  "
+
+    prompt = build_prompt(user_query, context, memory)
+
+    _, _, question_section = get_prompt_sections(prompt)
+    assert user_query.strip() in question_section
+
+
+def test_build_prompt_log_data_section_appears_between_context_and_question():
+    """Test that the 'User-Provided Log Data' section is placed
+    after the context section and before the user question."""
+    memory = ConversationBufferMemory(return_messages=True)
+    context = "Pipeline troubleshooting guide."
+    user_query = "Analyze this error."
+    log_context = "FATAL: command execution failed"
+
+    prompt = build_prompt(user_query, context, memory, log_context=log_context)
+
+    context_idx = prompt.index("Context (Documentation & Knowledge Base):")
+    log_data_idx = prompt.index("User-Provided Log Data:")
+    question_idx = prompt.index("User Question:")
+
+    # Log data must appear AFTER context and BEFORE question
+    assert context_idx < log_data_idx < question_idx
 
 def get_prompt_indexes(prompt: str) -> tuple[int, int, int, int]:
     """Helper to extract section positions in the prompt."""

--- a/chatbot-core/tests/unit/prompts/test_prompt_builder.py
+++ b/chatbot-core/tests/unit/prompts/test_prompt_builder.py
@@ -203,6 +203,7 @@ def test_build_prompt_with_none_content_message():
     history_section, _, _ = get_prompt_sections(prompt)
     # Should show "User: " with empty content, not crash
     assert "User: " in history_section
+    assert "Hello" not in history_section
 
 
 def test_build_prompt_with_special_characters_in_query():
@@ -234,6 +235,23 @@ def test_build_prompt_log_data_section_appears_between_context_and_question():
 
     # Log data must appear AFTER context and BEFORE question
     assert context_idx < log_data_idx < question_idx
+
+def test_build_prompt_with_whitespace_only_log_context_triggers_log_branch():
+    """Test that a whitespace-only log_context is truthy and triggers the
+    log analysis branch. This is the current intended behavior — the
+    log_context check uses `if log_context:` which treats non-empty
+    whitespace strings as truthy. If this behavior should change,
+    the source should be updated to use `if log_context and log_context.strip():`."""
+    memory = ConversationBufferMemory(return_messages=True)
+    context = "Some context."
+    user_query = "Why did my build fail?"
+
+    prompt = build_prompt(user_query, context, memory, log_context="   ")
+
+    # Whitespace-only string is truthy, so log analysis branch is triggered
+    assert LOG_ANALYSIS_INSTRUCTION.strip() in prompt
+    assert SYSTEM_INSTRUCTION.strip() not in prompt
+    assert "User-Provided Log Data:" in prompt
 
 def get_prompt_indexes(prompt: str) -> tuple[int, int, int, int]:
     """Helper to extract section positions in the prompt."""


### PR DESCRIPTION
Fixes #203 

## Summary

Expands the unit test coverage for `api/prompts/prompt_builder.py` by adding **8 new test cases** covering previously untested branches and edge cases. No production code is changed.

## Problem

The existing 4 tests in `test_prompt_builder.py` only exercise the default `log_context=None` path. The entire `if log_context:` branch (lines 37–42 of `prompt_builder.py`) — which switches to `LOG_ANALYSIS_INSTRUCTION` and injects the "User-Provided Log Data" section — had **zero dedicated test coverage**. Additionally, multi-turn conversation history and edge cases like `None` message content were untested.

## What changed

**Modified:** `chatbot-core/tests/unit/prompts/test_prompt_builder.py`
- Added import: `LOG_ANALYSIS_INSTRUCTION` from `api.prompts.prompts`
- Added 8 new test functions (all existing tests remain unchanged)

### New tests — `log_context` branch coverage

| Test | What it verifies |
|------|-----------------|
| `test_build_prompt_with_log_context_uses_log_analysis_instruction` | `LOG_ANALYSIS_INSTRUCTION` is used and log data section appears when `log_context` is provided |
| `test_build_prompt_with_log_context_and_history` | Full combination: `log_context` + conversation history + context together |
| `test_build_prompt_with_empty_string_log_context_uses_system_instruction` | Falsy `""` does NOT trigger the log analysis branch |
| `test_build_prompt_with_none_log_context_uses_system_instruction` | Default `None` value does NOT trigger the log analysis branch |
| `test_build_prompt_log_data_section_appears_between_context_and_question` | Log data section is placed after context and before user question |

### New tests — multi-turn history & edge cases

| Test | What it verifies |
|------|-----------------|
| `test_build_prompt_with_multiple_conversation_turns` | Multiple user/assistant rounds are captured in correct order (existing tests only had 1 turn) |
| `test_build_prompt_with_none_content_message` | The `msg.content or ''` guard handles `None` content without crashing |
| `test_build_prompt_with_special_characters_in_query` | Special characters (quotes, ampersands, angle brackets, newlines) are preserved |

## Changes

- `chatbot-core/tests/unit/prompts/test_prompt_builder.py` — modified, 8 new tests added

### Testing done

```bash
cd chatbot-core
$env:PYTHONPATH = (Get-Location).Path
pytest tests/unit/prompts/test_prompt_builder.py -v
```

Result: **12 passed** (4 existing + 8 new)

Full unit test suite also passes with no regressions.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed