### PR TITLE
enh: implement LLM query reformulation loop for low relevance context (fixes #191)

### DIFF
--- a/chatbot-core/api/prompts/prompts.py
+++ b/chatbot-core/api/prompts/prompts.py
@@ -291,3 +291,12 @@ Logs:
 
 Search Query:
 """
+QUERY_REFORMULATION_PROMPT = """
+The user asked the following question: "{original_query}"
+
+We tried to search our database for an answer and retrieved the following context, but it was not relevant enough to answer the question:
+{context}
+
+Please reformulate the user's query to be more specific, use different keywords, or approach the problem from a different angle so we can find better search results.
+Return ONLY the reformulated query text, without any additional explanation, quotes, or formatting.
+"""


### PR DESCRIPTION
What does this PR do?

Fixes #191.

Previously, the while loop in _get_reply_simple_query_pipeline() would execute multiple retrieval iterations when the context relevance was low, but it never mutated the search query. This resulted in identical LLM tool calls and identical failed context retrieval on every pass.

This PR introduces an LLM-powered query reformulation step. If the retrieved context scores a relevance of 0, the pipeline now passes the original query and the failed context to the LLM to generate a better, alternative search query before trying again.

Implementation Details:

Added QUERY_REFORMULATION_PROMPT to api/prompts/prompts.py to instruct the LLM on how to rephrase queries based on failed context.

Implemented _reformulate_query(original_query, context) in chat_service.py.

Refactored the while loop in _get_reply_simple_query_pipeline() to track and mutate current_query on subsequent iterations.

Added test_reformulation_loop_mutates_query in test_chat_service.py to verify the pipeline uses the newly generated queries.

Acceptance Criteria Met:

[x] QUERY_REFORMULATION_PROMPT added to prompts/prompts.py

[x] _reformulate_query() implemented and called inside the loop

[x] Unit test added: mocks relevance to return 0 twice then 1 -> asserts loop ran 3 times with different queries on iterations 2 and 3.