### PR TITLE
fix: harden _get_sub_queries against non-string LLM outputs (fixes #228)

### DIFF
--- a/chatbot-core/api/services/chat_service.py
+++ b/chatbot-core/api/services/chat_service.py
@@ -231,9 +231,34 @@ def _get_sub_queries(query: str) -> List[str]:
         logger.debug("Failed sub-query payload: %s", _sanitize_log_payload(queries_string))
         queries = [query]
 
-    queries = [q.strip() for q in queries]
+    if not isinstance(queries, (list, tuple)):
+        logger.warning(
+            "Subqueries output has invalid type %s. Setting to default array with 1 element.",
+            type(queries).__name__,
+        )
+        return [query]
 
-    return queries
+    normalized_queries = []
+    for sub_query in queries:
+        if not isinstance(sub_query, str):
+            logger.warning(
+                "Subquery item has invalid type %s. Skipping element.",
+                type(sub_query).__name__,
+            )
+            continue
+
+        stripped = sub_query.strip()
+        if stripped:
+            normalized_queries.append(stripped)
+
+    if not normalized_queries:
+        logger.warning(
+            "Subqueries output is empty after normalization. "
+            "Setting to default array with 1 element."
+        )
+        return [query]
+
+    return normalized_queries
 
 
 def _assemble_response(answers: List[str]):

--- a/chatbot-core/tests/unit/services/test_chat_service.py
+++ b/chatbot-core/tests/unit/services/test_chat_service.py
@@ -3,7 +3,12 @@
 import logging
 from unittest.mock import MagicMock
 import pytest
-from api.services.chat_service import generate_answer, get_chatbot_reply, retrieve_context
+from api.services.chat_service import (
+    _get_sub_queries,
+    generate_answer,
+    get_chatbot_reply,
+    retrieve_context,
+)
 from api.config.loader import CONFIG
 from api.models.schemas import ChatResponse
 
@@ -190,6 +195,65 @@ def test_retrieve_context_with_missing_code(mock_get_relevant_documents, caplog)
     )
     assert "More placeholders than code blocks in chunk with ID doc-111" in caplog.text
 
+
+def test_get_sub_queries_valid_list_of_strings(mocker):
+    """Should return stripped sub-queries when LLM output is valid list[str]."""
+    mocker.patch(
+        "api.services.chat_service.generate_answer",
+        return_value='["  install Jenkins  ", "configure github plugin"]',
+    )
+
+    queries = _get_sub_queries("How to install Jenkins and configure GitHub plugin?")
+
+    assert queries == ["install Jenkins", "configure github plugin"]
+
+
+def test_get_sub_queries_skips_non_string_items(mocker, caplog):
+    """Should skip invalid item types and keep valid strings."""
+    logging.getLogger("API").propagate = True
+    mocker.patch(
+        "api.services.chat_service.generate_answer",
+        return_value='["valid query", 42, None]',
+    )
+
+    with caplog.at_level(logging.WARNING):
+        queries = _get_sub_queries("Any query")
+
+    assert queries == ["valid query"]
+    assert "Subquery item has invalid type int" in caplog.text
+    assert "Subquery item has invalid type NoneType" in caplog.text
+
+
+def test_get_sub_queries_fallback_when_parsed_type_is_not_list(mocker, caplog):
+    """Should fallback to original query when parsed output is not list/tuple."""
+    logging.getLogger("API").propagate = True
+    original_query = "Original query"
+    mocker.patch(
+        "api.services.chat_service.generate_answer",
+        return_value='{"query": "not a list"}',
+    )
+
+    with caplog.at_level(logging.WARNING):
+        queries = _get_sub_queries(original_query)
+
+    assert queries == [original_query]
+    assert "Subqueries output has invalid type dict" in caplog.text
+
+
+def test_get_sub_queries_fallback_when_empty_after_normalization(mocker, caplog):
+    """Should fallback to original query when all parsed items are empty/invalid."""
+    logging.getLogger("API").propagate = True
+    original_query = "Original query"
+    mocker.patch(
+        "api.services.chat_service.generate_answer",
+        return_value='["   ", None, 0]',
+    )
+
+    with caplog.at_level(logging.WARNING):
+        queries = _get_sub_queries(original_query)
+
+    assert queries == [original_query]
+    assert "Subqueries output is empty after normalization" in caplog.text
 
 
 def get_mock_documents(doc_type: str):


### PR DESCRIPTION
﻿## Description
Fixes #228.

This PR hardens `_get_sub_queries()` against malformed-but-parseable LLM output so the agentic path does not crash on non-string items.

## What changed
- `chatbot-core/api/services/chat_service.py`
  - Added post-parse type guards in `_get_sub_queries()`:
    - fallback to `[query]` when parsed payload is not `list`/`tuple`
    - skip non-string items in parsed lists
    - trim/normalize string items
    - fallback to `[query]` when normalized list is empty
  - Added warning logs for invalid payload shapes/types.

- `chatbot-core/tests/unit/services/test_chat_service.py`
  - Added unit tests for:
    - valid list of strings
    - mixed list with non-string items
    - parsed payload as non-list type
    - empty-after-normalization fallback

## Why
`ast.literal_eval()` can return valid Python objects that are not safe for direct `.strip()` processing. Previously, non-string items could trigger runtime errors or degrade behavior. This PR ensures robust fallback behavior for agentic multi-query flow.

## Scope
- Focused to `_get_sub_queries()` robustness + unit tests.
- No architecture changes or new dependencies.

## Testing done
- `pytest tests/unit/services/test_chat_service.py -q` -> `11 passed`
- `pylint api/services/chat_service.py tests/unit/services/test_chat_service.py` -> `10.00/10`
