### PR TITLE
fix: guard unknown tool names and inject logger in _execute_search_tools()

### DIFF
--- a/chatbot-core/api/services/chat_service.py
+++ b/chatbot-core/api/services/chat_service.py
@@ -1,6 +1,7 @@
 """Chat service layer responsible for processing the requests forwarded by the controller."""
 
 import ast
+import inspect
 import json
 import re
 from typing import AsyncGenerator, List, Optional
@@ -325,6 +326,13 @@ def _execute_search_tools(tool_calls) -> str:
     for call in tool_calls:
         tool_name, params = call.get("tool"), call.get("params")
         tool_fn = TOOL_REGISTRY.get(tool_name)
+
+        if tool_fn is None:
+            logger.warning("Unknown tool name '%s'. Skipping.", tool_name)
+            continue
+
+        if "logger" in inspect.signature(tool_fn).parameters:
+            params = {**params, "logger": logger}
 
         result = tool_fn(**params)
         retrieved_results.append({

--- a/chatbot-core/tests/unit/services/test_chat_service.py
+++ b/chatbot-core/tests/unit/services/test_chat_service.py
@@ -2,8 +2,14 @@
 
 import logging
 from unittest.mock import MagicMock
+import inspect
 import pytest
-from api.services.chat_service import generate_answer, get_chatbot_reply, retrieve_context
+from api.services.chat_service import (
+    _execute_search_tools,
+    generate_answer,
+    get_chatbot_reply,
+    retrieve_context,
+)
 from api.config.loader import CONFIG
 from api.models.schemas import ChatResponse
 
@@ -237,10 +243,10 @@ def get_mock_documents(doc_type: str):
 
 
 # Tests for _execute_search_tools — Bug fix #241
-from api.services.chat_service import _execute_search_tools
 
 
 def test_execute_search_tools_unknown_tool_name_is_skipped(mocker):
+    """Test that unknown tool names are skipped gracefully without crashing."""
     mock_logger = mocker.patch("api.services.chat_service.logger")
     mock_registry = {}
     mocker.patch("api.services.chat_service.TOOL_REGISTRY", mock_registry)
@@ -253,7 +259,7 @@ def test_execute_search_tools_unknown_tool_name_is_skipped(mocker):
 
 
 def test_execute_search_tools_logger_injected_automatically(mocker):
-    import inspect
+    """Test that logger is automatically injected into tools that require it."""
     mock_tool = mocker.MagicMock(return_value="tool result")
     mocker.patch("api.services.chat_service.TOOL_REGISTRY", {"mock_tool": mock_tool})
     mocker.patch(
@@ -265,7 +271,7 @@ def test_execute_search_tools_logger_injected_automatically(mocker):
 
 
 def test_execute_search_tools_no_logger_not_injected(mocker):
-    import inspect
+    """Test that logger is NOT injected into tools that do not require it."""
     mock_tool = mocker.MagicMock(return_value="result")
     mocker.patch("api.services.chat_service.TOOL_REGISTRY", {"mock_tool": mock_tool})
     mocker.patch(
@@ -277,7 +283,7 @@ def test_execute_search_tools_no_logger_not_injected(mocker):
 
 
 def test_execute_search_tools_returns_combined_results(mocker):
-    import inspect
+    """Test that results from multiple tools are combined correctly."""
     mock_a = mocker.MagicMock(return_value="result A")
     mock_b = mocker.MagicMock(return_value="result B")
     mocker.patch("api.services.chat_service.TOOL_REGISTRY", {"tool_a": mock_a, "tool_b": mock_b})
@@ -294,7 +300,7 @@ def test_execute_search_tools_returns_combined_results(mocker):
 
 
 def test_execute_search_tools_mixed_valid_and_invalid(mocker):
-    import inspect
+    """Test that valid tools still execute when mixed with unknown tool names."""
     mock_logger = mocker.patch("api.services.chat_service.logger")
     mock_tool = mocker.MagicMock(return_value="valid result")
     mocker.patch("api.services.chat_service.TOOL_REGISTRY", {"valid_tool": mock_tool})

--- a/chatbot-core/tests/unit/services/test_chat_service.py
+++ b/chatbot-core/tests/unit/services/test_chat_service.py
@@ -152,3 +152,117 @@ def get_mock_documents(doc_type: str):
             }
         ]
     return []
+
+
+# Tests for _execute_search_tools — Bug fix #241
+from api.services.chat_service import _execute_search_tools
+from api.tools.tools import TOOL_REGISTRY
+
+
+def test_execute_search_tools_unknown_tool_name_is_skipped(mocker):
+    """Test that unknown tool names are skipped gracefully without crashing."""
+    mock_logger = mocker.patch("api.services.chat_service.logger")
+    tool_calls = [{"tool": "nonexistent_tool", "params": {"query": "test"}}]
+
+    result = _execute_search_tools(tool_calls)
+
+    assert result == ""
+    mock_logger.warning.assert_called_once_with(
+        "Unknown tool name '%s'. Skipping.", "nonexistent_tool"
+    )
+
+
+def test_execute_search_tools_logger_injected_automatically(mocker):
+    """Test that logger is automatically injected into tools that require it."""
+    mock_tool = mocker.MagicMock(return_value="tool result")
+    mocker.patch.dict(
+        "api.services.chat_service.TOOL_REGISTRY",
+        {"mock_tool_with_logger": mock_tool}
+    )
+
+    # Simulate a tool that requires logger in its signature
+    import inspect
+    mock_tool.__wrapped__ = None
+    mocker.patch(
+        "api.services.chat_service.inspect.signature",
+        return_value=inspect.signature(lambda query, logger: None)
+    )
+
+    tool_calls = [{"tool": "mock_tool_with_logger", "params": {"query": "test"}}]
+    result = _execute_search_tools(tool_calls)
+
+    call_kwargs = mock_tool.call_args[1]
+    assert "logger" in call_kwargs
+
+
+def test_execute_search_tools_no_logger_not_injected(mocker):
+    """Test that logger is NOT injected into tools that don't require it."""
+    mock_tool = mocker.MagicMock(return_value="stackoverflow result")
+    mocker.patch.dict(
+        "api.services.chat_service.TOOL_REGISTRY",
+        {"search_stackoverflow_threads": mock_tool}
+    )
+
+    import inspect
+    mocker.patch(
+        "api.services.chat_service.inspect.signature",
+        return_value=inspect.signature(lambda query: None)
+    )
+
+    tool_calls = [{"tool": "search_stackoverflow_threads", "params": {"query": "test"}}]
+    _execute_search_tools(tool_calls)
+
+    call_kwargs = mock_tool.call_args[1]
+    assert "logger" not in call_kwargs
+
+
+def test_execute_search_tools_returns_combined_results(mocker):
+    """Test that results from multiple tools are combined correctly."""
+    mock_tool_a = mocker.MagicMock(return_value="result A")
+    mock_tool_b = mocker.MagicMock(return_value="result B")
+    mocker.patch.dict(
+        "api.services.chat_service.TOOL_REGISTRY",
+        {"tool_a": mock_tool_a, "tool_b": mock_tool_b}
+    )
+
+    import inspect
+    mocker.patch(
+        "api.services.chat_service.inspect.signature",
+        return_value=inspect.signature(lambda query: None)
+    )
+
+    tool_calls = [
+        {"tool": "tool_a", "params": {"query": "test"}},
+        {"tool": "tool_b", "params": {"query": "test"}},
+    ]
+    result = _execute_search_tools(tool_calls)
+
+    assert "result A" in result
+    assert "result B" in result
+
+
+def test_execute_search_tools_mixed_valid_and_invalid(mocker):
+    """Test that valid tools still execute when mixed with unknown tool names."""
+    mock_logger = mocker.patch("api.services.chat_service.logger")
+    mock_tool = mocker.MagicMock(return_value="valid result")
+    mocker.patch.dict(
+        "api.services.chat_service.TOOL_REGISTRY",
+        {"valid_tool": mock_tool}
+    )
+
+    import inspect
+    mocker.patch(
+        "api.services.chat_service.inspect.signature",
+        return_value=inspect.signature(lambda query: None)
+    )
+
+    tool_calls = [
+        {"tool": "unknown_tool", "params": {"query": "test"}},
+        {"tool": "valid_tool", "params": {"query": "test"}},
+    ]
+    result = _execute_search_tools(tool_calls)
+
+    assert "valid result" in result
+    mock_logger.warning.assert_called_once_with(
+        "Unknown tool name '%s'. Skipping.", "unknown_tool"
+    )

--- a/chatbot-core/tests/unit/services/test_chat_service.py
+++ b/chatbot-core/tests/unit/services/test_chat_service.py
@@ -154,18 +154,17 @@ def get_mock_documents(doc_type: str):
     return []
 
 
+
 # Tests for _execute_search_tools — Bug fix #241
 from api.services.chat_service import _execute_search_tools
-from api.tools.tools import TOOL_REGISTRY
 
 
 def test_execute_search_tools_unknown_tool_name_is_skipped(mocker):
-    """Test that unknown tool names are skipped gracefully without crashing."""
     mock_logger = mocker.patch("api.services.chat_service.logger")
+    mock_registry = {}
+    mocker.patch("api.services.chat_service.TOOL_REGISTRY", mock_registry)
     tool_calls = [{"tool": "nonexistent_tool", "params": {"query": "test"}}]
-
     result = _execute_search_tools(tool_calls)
-
     assert result == ""
     mock_logger.warning.assert_called_once_with(
         "Unknown tool name '%s'. Skipping.", "nonexistent_tool"
@@ -173,95 +172,59 @@ def test_execute_search_tools_unknown_tool_name_is_skipped(mocker):
 
 
 def test_execute_search_tools_logger_injected_automatically(mocker):
-    """Test that logger is automatically injected into tools that require it."""
-    mock_tool = mocker.MagicMock(return_value="tool result")
-    mocker.patch.dict(
-        "api.services.chat_service.TOOL_REGISTRY",
-        {"mock_tool_with_logger": mock_tool}
-    )
-
-    # Simulate a tool that requires logger in its signature
     import inspect
-    mock_tool.__wrapped__ = None
+    mock_tool = mocker.MagicMock(return_value="tool result")
+    mocker.patch("api.services.chat_service.TOOL_REGISTRY", {"mock_tool": mock_tool})
     mocker.patch(
         "api.services.chat_service.inspect.signature",
         return_value=inspect.signature(lambda query, logger: None)
     )
-
-    tool_calls = [{"tool": "mock_tool_with_logger", "params": {"query": "test"}}]
-    result = _execute_search_tools(tool_calls)
-
-    call_kwargs = mock_tool.call_args[1]
-    assert "logger" in call_kwargs
+    _execute_search_tools([{"tool": "mock_tool", "params": {"query": "test"}}])
+    assert "logger" in mock_tool.call_args[1]
 
 
 def test_execute_search_tools_no_logger_not_injected(mocker):
-    """Test that logger is NOT injected into tools that don't require it."""
-    mock_tool = mocker.MagicMock(return_value="stackoverflow result")
-    mocker.patch.dict(
-        "api.services.chat_service.TOOL_REGISTRY",
-        {"search_stackoverflow_threads": mock_tool}
-    )
-
     import inspect
+    mock_tool = mocker.MagicMock(return_value="result")
+    mocker.patch("api.services.chat_service.TOOL_REGISTRY", {"mock_tool": mock_tool})
     mocker.patch(
         "api.services.chat_service.inspect.signature",
         return_value=inspect.signature(lambda query: None)
     )
-
-    tool_calls = [{"tool": "search_stackoverflow_threads", "params": {"query": "test"}}]
-    _execute_search_tools(tool_calls)
-
-    call_kwargs = mock_tool.call_args[1]
-    assert "logger" not in call_kwargs
+    _execute_search_tools([{"tool": "mock_tool", "params": {"query": "test"}}])
+    assert "logger" not in mock_tool.call_args[1]
 
 
 def test_execute_search_tools_returns_combined_results(mocker):
-    """Test that results from multiple tools are combined correctly."""
-    mock_tool_a = mocker.MagicMock(return_value="result A")
-    mock_tool_b = mocker.MagicMock(return_value="result B")
-    mocker.patch.dict(
-        "api.services.chat_service.TOOL_REGISTRY",
-        {"tool_a": mock_tool_a, "tool_b": mock_tool_b}
-    )
-
     import inspect
+    mock_a = mocker.MagicMock(return_value="result A")
+    mock_b = mocker.MagicMock(return_value="result B")
+    mocker.patch("api.services.chat_service.TOOL_REGISTRY", {"tool_a": mock_a, "tool_b": mock_b})
     mocker.patch(
         "api.services.chat_service.inspect.signature",
         return_value=inspect.signature(lambda query: None)
     )
-
-    tool_calls = [
+    result = _execute_search_tools([
         {"tool": "tool_a", "params": {"query": "test"}},
         {"tool": "tool_b", "params": {"query": "test"}},
-    ]
-    result = _execute_search_tools(tool_calls)
-
+    ])
     assert "result A" in result
     assert "result B" in result
 
 
 def test_execute_search_tools_mixed_valid_and_invalid(mocker):
-    """Test that valid tools still execute when mixed with unknown tool names."""
+    import inspect
     mock_logger = mocker.patch("api.services.chat_service.logger")
     mock_tool = mocker.MagicMock(return_value="valid result")
-    mocker.patch.dict(
-        "api.services.chat_service.TOOL_REGISTRY",
-        {"valid_tool": mock_tool}
-    )
-
-    import inspect
+    mocker.patch("api.services.chat_service.TOOL_REGISTRY", {"valid_tool": mock_tool})
     mocker.patch(
         "api.services.chat_service.inspect.signature",
         return_value=inspect.signature(lambda query: None)
     )
-
-    tool_calls = [
+    result = _execute_search_tools([
         {"tool": "unknown_tool", "params": {"query": "test"}},
         {"tool": "valid_tool", "params": {"query": "test"}},
-    ]
-    result = _execute_search_tools(tool_calls)
-
+    ])
     assert "valid result" in result
     mock_logger.warning.assert_called_once_with(
         "Unknown tool name '%s'. Skipping.", "unknown_tool"


### PR DESCRIPTION
## What this PR does
Fixes two bugs in `_execute_search_tools()` in `chat_service.py` that caused 
the entire agentic pipeline to crash silently.

## Problem
**Bug 1 — No guard for unknown tool names**
If the LLM generates a tool name not in `TOOL_REGISTRY`, 
`TOOL_REGISTRY.get(tool_name)` returns `None`. 
Calling `None(**params)` throws `TypeError` with no error handling.

**Bug 2 — Logger not injected into tool calls**
Three of the four tools require a `logger` argument but the 
LLM-generated `params` dict never includes it, causing 
`TypeError: missing required argument: 'logger'`.

## Fix
- Added `None` check for unknown tool names with a warning log and `continue`
- Auto-inject `logger` into tools that require it using `inspect.signature()`
- Moved `import inspect` to module level

## Tests Added
5 new unit tests in `test_chat_service.py`:
- `test_execute_search_tools_unknown_tool_name_is_skipped`
- `test_execute_search_tools_logger_injected_automatically`
- `test_execute_search_tools_no_logger_not_injected`
- `test_execute_search_tools_returns_combined_results`
- `test_execute_search_tools_mixed_valid_and_invalid`

Closes #190