### PR TITLE
feat: implement search_stackoverflow_threads with StackExchange API

### DIFF
--- a/chatbot-core/api/config/config-testing.yml
+++ b/chatbot-core/api/config/config-testing.yml
@@ -36,6 +36,9 @@ tool_names:
   jenkins_docs: "docs"
   community_threads: "discourse"
 
+stackoverflow:
+  page_size: 5
+
 cors:
   allowed_origins:
     - "*"

--- a/chatbot-core/api/config/config.yml
+++ b/chatbot-core/api/config/config.yml
@@ -36,6 +36,9 @@ tool_names:
   jenkins_docs: "docs"
   community_threads: "discourse"
 
+stackoverflow:
+  page_size: 5
+
 cors:
   allowed_origins:
     - "*"

--- a/chatbot-core/api/prompts/prompts.py
+++ b/chatbot-core/api/prompts/prompts.py
@@ -120,7 +120,7 @@ You are JenkinsBot, an expert assistant for Jenkins and its ecosystem.
 You have access to the following tools to retrieve relevant information:
 1. search_jenkins_docs(query, keywords) - Retrieves information from official Jenkins documentation. Use this for core Jenkins concepts, features, configuration, and usage. You must also extract appropriate keywords from the query to fill the keywords parameter.
 2. search_plugin_docs(query, keywords, plugin_name) - Retrieves information from official documentation related to a specific Jenkins plugin. Use this when the user query involves a known or suspected plugin. If the plugin name is unclear or unknown, pass null for the plugin_name. You must also extract appropriate keywords from the query to fill the keywords parameter.
-3. search_stackoverflow_threads(query) - Retrieves discussions from StackOverflow related to Jenkins issues. Ideal for troubleshooting specific errors, unexpected behavior, or edge cases.
+3. search_stackoverflow_threads(query, keywords) - Retrieves discussions from StackOverflow related to Jenkins issues. Ideal for troubleshooting specific errors, unexpected behavior, or edge cases. You must also extract appropriate keywords from the query to fill the keywords parameter.
 4. search_community_threads(query, keywords) - Retrieves Jenkins-related posts from community forums. Also ideal for troubleshooting, user workarounds, or undocumented use cases. You must also extract appropriate keywords from the query to fill the keywords parameter.
 
 Your task is to:
@@ -154,7 +154,8 @@ Tool calls:
   {{
     "tool": "search_stackoverflow_threads",
     "params": {{
-      "query": "jenkins slack plugin stops working after pipeline failure"
+      "query": "jenkins slack plugin stops working after pipeline failure",
+      "keywords": "slack plugin pipeline failure"
     }}
   }}
 ]
@@ -177,7 +178,8 @@ Tool calls:
   {{
     "tool": "search_stackoverflow_threads",
     "params": {{
-      "query": "jenkins plugin dependency error after upgrade"
+      "query": "jenkins plugin dependency error after upgrade",
+      "keywords": "plugin dependency error upgrade"
     }}
   }},
   {{

--- a/chatbot-core/api/tools/tools.py
+++ b/chatbot-core/api/tools/tools.py
@@ -2,8 +2,10 @@
 Definition of the tools avaialable to the Agent.
 """
 
+import re
 from typing import Optional
 from types import MappingProxyType
+import requests
 from api.models.embedding_model import EMBEDDING_MODEL
 from api.tools.utils import (
     filter_retrieved_data,
@@ -87,13 +89,78 @@ def search_jenkins_docs(query: str, keywords: str, logger) -> str:
         logger=logger
     )
 
-def search_stackoverflow_threads(query: str) -> str:
+def _strip_html(html: str) -> str:
+    """Remove HTML tags from a string."""
+    return re.sub(r"<[^>]+>", "", html)
+
+
+def _format_so_item(item: dict) -> str:
+    """Format a single StackOverflow API item into a readable string."""
+    body = _strip_html(item.get("body", ""))
+    if len(body) > 500:
+        body = body[:500] + "..."
+    return (
+        f"**{item.get('title', '')}** "
+        f"(score: {item.get('score', 0)}, "
+        f"answers: {item.get('answer_count', 0)}, "
+        f"accepted: {item.get('is_answered', False)})\n"
+        f"{body}\n"
+        f"Link: {item.get('link', '')}"
+    )
+
+
+# pylint: disable=unused-argument
+def search_stackoverflow_threads(query: str, keywords: str, logger) -> str:
     """
-    Stackoverflow Search tool
+    Search StackOverflow for Jenkins-related threads using the
+    StackExchange API.
+
+    Args:
+        query (str): The user query.
+        keywords (str): Keywords extracted from the user query.
+            Currently unused; reserved for future keyword-based
+            filtering.
+        logger: Logger object.
+
+    Returns:
+        str: Formatted results from StackOverflow, or a fallback
+             message if no results are found or the API call fails.
     """
-    if query:
-        pass
-    return "Nothing relevant"
+    stackoverflow_config = CONFIG.get("stackoverflow", {})
+    page_size = stackoverflow_config.get("page_size", 5)
+    api_key = stackoverflow_config.get("api_key")
+
+    params = {
+        "order": "desc",
+        "sort": "relevance",
+        "q": query,
+        "tagged": "jenkins",
+        "site": "stackoverflow",
+        "filter": "withbody",
+        "pagesize": page_size,
+        "accepted": "True",
+    }
+    if api_key:
+        params["key"] = api_key
+
+    try:
+        resp = requests.get(
+            "https://api.stackexchange.com/2.3/search/advanced",
+            params=params,
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:
+        logger.warning("StackOverflow API request failed: %s", exc)
+        return retrieval_config["empty_context_message"]
+
+    items = data.get("items", [])
+    if not items:
+        logger.info("No StackOverflow results for query: %s", query)
+        return retrieval_config["empty_context_message"]
+
+    return "\n\n---\n\n".join(_format_so_item(item) for item in items)
 
 def search_community_threads(query: str, keywords: str, logger) -> str:
     """

--- a/chatbot-core/api/tools/utils.py
+++ b/chatbot-core/api/tools/utils.py
@@ -19,7 +19,7 @@ CODE_BLOCK_PLACEHOLDER_PATTERN = r"\[\[(?:CODE_BLOCK|CODE_SNIPPET)_(\d+)\]\]"
 TOOL_SIGNATURES = MappingProxyType({
     "search_plugin_docs": {"plugin_name": str, "query": str},
     "search_jenkins_docs": {"query": str},
-    "search_stackoverflow_threads": {"query": str},
+    "search_stackoverflow_threads": {"query": str, "keywords": str},
     "search_community_threads": {"query": str},
 })
 
@@ -51,7 +51,8 @@ def get_default_tools_call(query: str):
         {
             "tool": "search_stackoverflow_threads",
             "params": {
-                "query": query
+                "query": query,
+                "keywords": query
             }
         },
         {


### PR DESCRIPTION
Fixes #216

## What it does
Replaces the [search_stackoverflow_threads()](cci:1://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/tools/tools.py:112:0-162:70) no-op stub that always returned `"Nothing relevant"` with a real [StackExchange API](https://api.stackexchange.com/docs/advanced-search) integration.

## Changes

| File | What changed |
|------|-------------|
| [tools.py](cci:7://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/tools/tools.py:0:0-0:0) | Real implementation using `GET /2.3/search/advanced`, [_strip_html()](cci:1://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/tools/tools.py:91:0-93:39) + [_format_so_item()](cci:1://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/tools/tools.py:96:0-108:5) helpers, `logger` + `keywords` params added for consistency |
| [utils.py](cci:7://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/tools/utils.py:0:0-0:0) | Added `keywords` to `TOOL_SIGNATURES` and default tool calls |
| [prompts.py](cci:7://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/prompts/prompts.py:0:0-0:0) | Updated tool description and both JSON examples with `keywords` param |
| [config.yml](cci:7://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/config/config.yml:0:0-0:0) | Added `stackoverflow.page_size: 5` |
| [config-testing.yml](cci:7://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/config/config-testing.yml:0:0-0:0) | Same |

## How it works
1. Calls `GET https://api.stackexchange.com/2.3/search/advanced` with `tagged=jenkins`, `sort=relevance`, `filter=withbody`
2. Strips HTML from response bodies, truncates to 500 chars
3. Formats results with title, score, answer count, accepted status, and link
4. Falls back gracefully to `empty_context_message` on API errors or empty results
5. Configurable `page_size` and optional `api_key` via [config.yml](cci:7://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/config/config.yml:0:0-0:0)

## Design decisions
- **No new dependencies** - `requests` is already in [requirements.txt](cci:7://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/requirements.txt:0:0-0:0)
- **`keywords` param accepted but unused** - reserved for future keyword-based filtering, keeps signature consistent with the other 3 tools
- **`logger` param added** - aligns with [search_plugin_docs](cci:1://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/tools/tools.py:19:0-57:5), [search_jenkins_docs](cci:1://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/tools/tools.py:59:0-89:5), [search_community_threads](cci:1://file:///home/nageswara/Desktop/resources-ai-chatbot-plugin/chatbot-core/api/tools/tools.py:164:0-196:5) (also fixes #190 compatibility)
- **No auth key needed** - StackExchange API allows 300 req/day without a key; optional `api_key` config bumps to 10k/day

## Related
- Parent: #190 (`_execute_search_tools` crash bugs)
- Sibling: #189 (agentic pipeline dead code)