### PR TITLE
fix: delete_session() now cleans up disk-only session files (fixes #258)

### DIFF
--- a/chatbot-core/api/services/memory.py
+++ b/chatbot-core/api/services/memory.py
@@ -115,10 +115,11 @@ def delete_session(session_id: str) -> bool:
             return True
         in_memory_deleted = _sessions.pop(session_id, None) is not None
 
-    if in_memory_deleted:
+    on_disk = session_exists_in_json(session_id)
+    if on_disk:
         delete_session_file(session_id)
 
-    return in_memory_deleted
+    return in_memory_deleted or on_disk
 
 
 def session_exists(session_id: str) -> bool:


### PR DESCRIPTION
Fixes #258
## problem
`delete_session()` only deletes the disk file if the session was found in the in-memory `_sessions` dict. Sessions that exist only on disk (e.g. after server restart before `reload_persisted_sessions()` runs) are silently ignored, leaving orphaned `.json` files that accumulate over time.

## fix
check `session_exists_in_json()` independently of in-memory state and delete the disk file if present. return `True` if either in-memory or on-disk deletion occurred.
## changes
| file | what changed |
|------|-------------|
| `memory.py` | `delete_session()` now checks disk via `session_exists_in_json()` as fallback |
