### PR TITLE
fix: embedding non-plugin sources and adding light metadata (#262)

### DIFF
--- a/chatbot-core/api/services/chat_service.py
+++ b/chatbot-core/api/services/chat_service.py
@@ -390,9 +390,11 @@ def retrieve_context(user_input: str) -> str:
         return "No context available."
 
     context_texts = []
+    seen_texts = set()
     for item in data_retrieved:
         item_id = item.get("id", "")
         text = item.get("chunk_text", "")
+        item_metadata = item.get("metadata") or {}
         if not item_id:
             logger.warning(
                 "Id of retrieved context not found. Skipping element.")
@@ -402,6 +404,31 @@ def retrieve_context(user_input: str) -> str:
             replace = make_placeholder_replacer(code_iter, item_id, logger)
             text = re.sub(CODE_BLOCK_PLACEHOLDER_PATTERN, replace, text)
 
+            # adding light metadata header when present (docs/discourse).
+            if item_metadata:
+                header_parts = []
+                data_source = item_metadata.get("data_source")
+                title = item_metadata.get("title")
+                source_url = item_metadata.get("source_url")
+                topic_id = item_metadata.get("topic_id")
+
+                if data_source:
+                    header_parts.append(str(data_source))
+                if title:
+                    header_parts.append(str(title))
+                if source_url:
+                    header_parts.append(str(source_url))
+                elif topic_id is not None:
+                    header_parts.append(f"topic_id={topic_id}")
+
+                if header_parts:
+                    text = f"[{' | '.join(header_parts)}]\n{text}"
+
+            # Deduplicate repeated chunks
+            dedupe_key = " ".join(text.split())
+            if dedupe_key in seen_texts:
+                continue
+            seen_texts.add(dedupe_key)
             context_texts.append(text)
         else:
             logger.warning("Text of chunk with ID %s is missing", item_id)

--- a/chatbot-core/rag/embedding/embed_chunks.py
+++ b/chatbot-core/rag/embedding/embed_chunks.py
@@ -11,10 +11,10 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROCESSED_DIR = os.path.join(SCRIPT_DIR, "..", "..", "data", "processed")
 MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
 CHUNK_FILES = [
-    #"chunks_docs.json",
+    "chunks_docs.json",
     "chunks_plugin_docs.json",
-    #"chunks_discourse_docs.json",
-    #"chunks_stackoverflow_threads.json"
+    "chunks_discourse_docs.json",
+    "chunks_stackoverflow_threads.json",
 ]
 
 def load_chunks_from_file(path, logger):


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
## Description
**Embed Jenkins docs + Discourse + StackOverflow corpora and standardize metadata **

This PR extends the embedding pipeline so that it includes all major knowledge sources produced by the data pipeline, rather than embedding only plugin documentation.
It also introduces a small metadata standardization step to ensure that every embedded record stored in the metadata `.pkl` file contains a consistent `metadata.data_source` field. This makes it possible to distinguish between corpora during retrieval and enables better filtering and formatting of results downstream.

## Changes

- Updated `embed_chunks.py` to load embeddings from the following chunk sources:
  - `chunks_docs.json`
  - `chunks_plugin_docs.json`
  - `chunks_discourse_docs.json`
  - `chunks_stackoverflow_threads.json`

- Added a metadata standardization step to ensure that `metadata.data_source` and other details are present when the chunks are getting embedded.

- When the field is missing, it is automatically inferred from the originating chunk file, ensuring consistent metadata across all embedded records.

## How to Test

1. Regenerate embeddings using the embedding pipeline.
2. Verify that the generated `.pkl` metadata file now contains records from multiple sources.
3. Confirm that each metadata record includes a valid `metadata.data_source` field.
4. Run a few example queries that should retrieve information from:
   - Jenkins documentation  
   - Discourse threads  
   - StackOverflow discussions  
5. Confirm that retrieval results now include multiple sources instead of only plugin documentation.

## Proof of Concept (PoC)

To demonstrate the effect of this change, I tested the chatbot before and after applying this PR. The questions were random and  involved the details of discourse / stackoverflow / jenkins docs .

### Before This PR

When the embeddings only included plugin documentation, the chatbot was unable to confidently answer questions whose answers exist in Jenkins core documentation or community discussions.
[pre_pr_chat.md](https://github.com/user-attachments/files/25824170/pre_pr_chat.md)


### After This PR

After embedding Jenkins documentation, Discourse threads, and StackOverflow discussions, the chatbot is able to retrieve the correct context and produce a confident response.
[post_pr_chat.md](https://github.com/user-attachments/files/25824172/post_pr_chat.md)



