### PR TITLE
fix(make): correct run-data-storage script path (fixes #269)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ run-data-chunking: run-data-chunking-docs run-data-chunking-plugins run-data-chu
 run-data-storage: setup-backend
 	@$(BACKEND_SHELL) && \
 	echo "### EMBEDDING AND STORING THE CHUNKS ###" && \
-	python3 data/rag/vectorstore/store_embeddings.py
+	python3 rag/vectorstore/store_embeddings.py
 
 
 run-pipeline-core: run-data-collection run-data-preprocessing run-data-chunking run-data-storage


### PR DESCRIPTION
## Summary
Fixes `run-data-storage` in `Makefile` to call the correct script path.

## Problem
`run-data-storage` was invoking:
- `python3 data/rag/vectorstore/store_embeddings.py`

That file path does not exist.
The actual script is:
- `rag/vectorstore/store_embeddings.py`

This makes the target fail when running the data pipeline storage phase.

## Change
- Updated `Makefile` target `run-data-storage` to call:
  - `python3 rag/vectorstore/store_embeddings.py`

## Why this is safe
- No behavior change beyond fixing a broken path.
- Aligns Make target with existing docs (`docs/chatbot-core/rag/vectorstore.md`).

Fixes #269.
