### PR TITLE
tests: cover schemas helpers, sanitizer gaps, prompt log_context branch

### DIFF
--- a/chatbot-core/tests/unit/models/test_schemas.py
+++ b/chatbot-core/tests/unit/models/test_schemas.py
@@ -1,0 +1,151 @@
+"""Unit tests for query-type helpers and request validators in schemas.py."""
+# pylint: disable=redefined-outer-name
+
+import logging
+
+import pytest
+
+from api.models.schemas import (
+    ChatRequest,
+    ChatRequestWithFiles,
+    FileAttachment,
+    FileType,
+    QueryType,
+    is_valid_query_type,
+    str_to_query_type,
+    try_str_to_query_type,
+)
+
+
+class TestIsValidQueryType:
+    """is_valid_query_type should accept only exact enum member names."""
+
+    def test_simple_is_valid(self):
+        """SIMPLE is a recognised member."""
+        assert is_valid_query_type("SIMPLE") is True
+
+    def test_multi_is_valid(self):
+        """MULTI is a recognised member."""
+        assert is_valid_query_type("MULTI") is True
+
+    def test_lowercase_rejected(self):
+        """Enum lookup is case-sensitive."""
+        assert is_valid_query_type("simple") is False
+
+    def test_empty_string_rejected(self):
+        """Empty string is not a member."""
+        assert is_valid_query_type("") is False
+
+    def test_unknown_string_rejected(self):
+        """Arbitrary strings must be rejected."""
+        assert is_valid_query_type("COMPLEX") is False
+
+
+class TestStrToQueryType:
+    """str_to_query_type converts valid strings or raises ValueError."""
+
+    def test_converts_simple(self):
+        """SIMPLE string maps to QueryType.SIMPLE."""
+        assert str_to_query_type("SIMPLE") == QueryType.SIMPLE
+
+    def test_converts_multi(self):
+        """MULTI string maps to QueryType.MULTI."""
+        assert str_to_query_type("MULTI") == QueryType.MULTI
+
+    def test_invalid_string_raises(self):
+        """Unrecognised input raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid query type"):
+            str_to_query_type("UNKNOWN")
+
+    def test_empty_string_raises(self):
+        """Empty input raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid query type"):
+            str_to_query_type("")
+
+
+class TestTryStrToQueryType:
+    """try_str_to_query_type falls back to MULTI on bad input."""
+
+    @pytest.fixture()
+    def logger(self):
+        """Provide a logger for the function under test."""
+        return logging.getLogger("test_schemas")
+
+    def test_valid_simple(self, logger):
+        """Valid SIMPLE string converts normally."""
+        assert try_str_to_query_type("SIMPLE", logger) == QueryType.SIMPLE
+
+    def test_valid_multi(self, logger):
+        """Valid MULTI string converts normally."""
+        assert try_str_to_query_type("MULTI", logger) == QueryType.MULTI
+
+    def test_invalid_falls_back_to_multi(self, logger):
+        """Bad input defaults to MULTI instead of crashing."""
+        assert try_str_to_query_type("garbage", logger) == QueryType.MULTI
+
+    def test_empty_falls_back_to_multi(self, logger):
+        """Empty string defaults to MULTI."""
+        assert try_str_to_query_type("", logger) == QueryType.MULTI
+
+
+class TestChatRequestValidation:
+    """ChatRequest.message validator rejects empty/whitespace messages."""
+
+    def test_normal_message_accepted(self):
+        """Regular text passes validation."""
+        req = ChatRequest(message="Hello Jenkins!")
+        assert req.message == "Hello Jenkins!"
+
+    def test_empty_string_rejected(self):
+        """Empty string is not a valid message."""
+        with pytest.raises(ValueError, match="Message cannot be empty"):
+            ChatRequest(message="")
+
+    def test_whitespace_only_rejected(self):
+        """Spaces-only message is treated as empty."""
+        with pytest.raises(ValueError, match="Message cannot be empty"):
+            ChatRequest(message="   ")
+
+
+class TestChatRequestWithFilesValidation:
+    """ChatRequestWithFiles requires at least a message or a file."""
+
+    @pytest.fixture()
+    def sample_attachment(self):
+        """Minimal valid file attachment for reuse across tests."""
+        return FileAttachment(
+            filename="readme.txt",
+            type=FileType.TEXT,
+            content="hello",
+            mime_type="text/plain",
+        )
+
+    def test_message_only(self):
+        """Message without files is fine."""
+        req = ChatRequestWithFiles(message="Hi")
+        assert req.message == "Hi"
+
+    def test_files_only(self, sample_attachment):
+        """Files without a message is fine."""
+        req = ChatRequestWithFiles(message="", files=[sample_attachment])
+        assert len(req.files) == 1
+
+    def test_both_message_and_files(self, sample_attachment):
+        """Both provided together should work."""
+        req = ChatRequestWithFiles(message="Analyze this", files=[sample_attachment])
+        assert req.message == "Analyze this"
+
+    def test_no_message_no_files_rejected(self):
+        """Sending neither message nor files is invalid."""
+        with pytest.raises(ValueError, match="Either message or files must be provided"):
+            ChatRequestWithFiles(message="", files=None)
+
+    def test_whitespace_message_no_files_rejected(self):
+        """Whitespace-only message with no files is invalid."""
+        with pytest.raises(ValueError, match="Either message or files must be provided"):
+            ChatRequestWithFiles(message="   ", files=None)
+
+    def test_empty_files_list_no_message_rejected(self):
+        """Empty list counts the same as None for files."""
+        with pytest.raises(ValueError, match="Either message or files must be provided"):
+            ChatRequestWithFiles(message="", files=[])

--- a/chatbot-core/tests/unit/prompts/test_prompt_builder.py
+++ b/chatbot-core/tests/unit/prompts/test_prompt_builder.py
@@ -96,3 +96,44 @@ def get_prompt_sections(prompt: str) -> tuple[str, str, str]:
     question_section = prompt.split("User Question:")[1].split("Answer:")[0]
 
     return history_section, context_section, question_section
+
+
+# The log_context parameter was added in PR #89 but never got test
+# coverage.  These three tests cover the LOG_ANALYSIS_INSTRUCTION branch.
+
+
+def test_build_prompt_with_log_context_uses_log_analysis_instruction():
+    """Passing log_context should swap the system prompt to LOG_ANALYSIS_INSTRUCTION."""
+    from api.prompts.prompt_builder import LOG_ANALYSIS_INSTRUCTION  # pylint: disable=import-outside-toplevel
+
+    memory = ConversationBufferMemory(return_messages=True)
+    prompt = build_prompt(
+        "Why did my build fail?",
+        "Jenkins pipeline docs.",
+        memory,
+        log_context="ERROR: Build step failed with exit code 1",
+    )
+
+    assert LOG_ANALYSIS_INSTRUCTION.strip() in prompt
+    assert SYSTEM_INSTRUCTION.strip() not in prompt
+
+
+def test_build_prompt_with_log_context_includes_log_data():
+    """The raw log text must appear under 'User-Provided Log Data'."""
+    memory = ConversationBufferMemory(return_messages=True)
+    log_text = "java.lang.NullPointerException at com.example.Main"
+
+    prompt = build_prompt("Diagnose this", "ctx", memory, log_context=log_text)
+
+    assert "User-Provided Log Data:" in prompt
+    assert log_text in prompt
+
+
+def test_build_prompt_without_log_context_omits_log_section():
+    """When log_context is None the prompt should use SYSTEM_INSTRUCTION
+    and not contain a log-data section at all."""
+    memory = ConversationBufferMemory(return_messages=True)
+    prompt = build_prompt("Hello", "ctx", memory, log_context=None)
+
+    assert SYSTEM_INSTRUCTION.strip() in prompt
+    assert "User-Provided Log Data:" not in prompt

--- a/chatbot-core/tests/unit/tools/test_sanitizer.py
+++ b/chatbot-core/tests/unit/tools/test_sanitizer.py
@@ -31,5 +31,46 @@ class TestLogSanitizer(unittest.TestCase):
         log = "Build step 'Execute Windows batch command' marked build as failure"
         self.assertEqual(sanitize_logs(log), log)
 
+    # The patterns below exist in sanitizer.py but had no tests.
+
+    def test_sanitize_bearer_token(self):
+        """Bearer tokens should be replaced with [REDACTED_TOKEN]."""
+        log = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"
+        result = sanitize_logs(log)
+        self.assertNotIn("eyJhbGciOiJIUzI1NiJ9", result)
+        self.assertIn("[REDACTED_TOKEN]", result)
+
+    def test_sanitize_github_token(self):
+        """GitHub PATs (ghp_...) should be replaced with [REDACTED_GITHUB_TOKEN]."""
+        log = "GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        result = sanitize_logs(log)
+        self.assertNotIn("ghp_ABCDEF", result)
+        self.assertIn("[REDACTED_GITHUB_TOKEN]", result)
+
+    def test_sanitize_private_key_block(self):
+        """PEM private key blocks should be replaced with [REDACTED_PRIVATE_KEY]."""
+        log = (
+            "-----BEGIN RSA PRIVATE KEY-----\n"
+            "MIIBogIBAAJBAKxL\n"
+            "-----END RSA PRIVATE KEY-----"
+        )
+        result = sanitize_logs(log)
+        self.assertNotIn("MIIBogIBAAJBAKxL", result)
+        self.assertIn("[REDACTED_PRIVATE_KEY]", result)
+
+    def test_sanitize_client_secret(self):
+        """client_secret=... should be redacted like other password-style keys."""
+        log = "client_secret=superSecretOAuthValue"
+        result = sanitize_logs(log)
+        self.assertNotIn("superSecretOAuthValue", result)
+        self.assertIn("[REDACTED]", result)
+
+    def test_sanitize_api_key_with_colon(self):
+        """api_key: ... (colon separator) should also be caught."""
+        log = "api_key: sk-proj-1234567890abcdef"
+        result = sanitize_logs(log)
+        self.assertNotIn("sk-proj-1234567890abcdef", result)
+        self.assertIn("[REDACTED]", result)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds 30 unit tests covering previously-untested code.

Fixes #321

**`tests/unit/models/test_schemas.py`** (22 tests, new file)
- `is_valid_query_type` - valid members, case sensitivity, empty string
- `str_to_query_type` - valid conversion, ValueError on bad input
- `try_str_to_query_type` - fallback to MULTI on bad input
- `ChatRequest` - accepts valid messages, rejects empty/whitespace
- `ChatRequestWithFiles` - message-only, files-only, both, neither

**`tests/unit/prompts/test_prompt_builder.py`** (3 tests appended)
- `log_context` provided uses `LOG_ANALYSIS_INSTRUCTION` and includes log data
- `log_context=None` uses standard `SYSTEM_INSTRUCTION`, no log section

**`tests/unit/tools/test_sanitizer.py`** (5 tests appended)
- Bearer token, GitHub PAT (`ghp_`), PEM private key block, `client_secret`, `api_key` with colon

How to run:

    cd chatbot-core && export PYTHONPATH=$(pwd)
    pytest tests/unit/models/test_schemas.py \
           tests/unit/prompts/test_prompt_builder.py \
           tests/unit/tools/test_sanitizer.py -v

All 38 tests pass (30 new + 8 existing). No source changes, no new deps.