### PR TITLE
Fix frontend mount point mismatch in Jenkins plugin UI

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,7 +3,11 @@ import { createRoot } from "react-dom/client";
 import { Chatbot } from "./components/Chatbot";
 import "./index.css";
 
-const footerRoot = document.getElementById("root")!;
+const footerRoot = document.getElementById("chatbot-root");
+
+if (!footerRoot) {
+  throw new Error("Chatbot root element '#chatbot-root' was not found.");
+}
 
 createRoot(footerRoot).render(
   <StrictMode>

--- a/frontend/src/tests/main.test.tsx
+++ b/frontend/src/tests/main.test.tsx
@@ -1,0 +1,38 @@
+const renderMock = jest.fn();
+const createRootMock = jest.fn(() => ({
+  render: renderMock,
+}));
+
+jest.mock("react-dom/client", () => ({
+  createRoot: createRootMock,
+}));
+
+jest.mock("../components/Chatbot", () => ({
+  Chatbot: () => <div>Mock Chatbot</div>,
+}));
+
+describe("frontend entrypoint", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    renderMock.mockClear();
+    createRootMock.mockClear();
+    document.body.innerHTML = "";
+  });
+
+  it("mounts the chatbot into the plugin footer root", async () => {
+    document.body.innerHTML = '<div id="chatbot-root"></div>';
+
+    await import("../main");
+
+    expect(createRootMock).toHaveBeenCalledWith(
+      document.getElementById("chatbot-root"),
+    );
+    expect(renderMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a clear error when the plugin footer root is missing", async () => {
+    await expect(import("../main")).rejects.toThrow(
+      "Chatbot root element '#chatbot-root' was not found.",
+    );
+  });
+});


### PR DESCRIPTION
This PR fixes a small mismatch between the Jenkins footer template and the frontend entrypoint.

The footer already renders the chatbot container as `chatbot-root`, but the React entrypoint was trying to mount the app into `root`. I updated the frontend to use the same mount target as the plugin template and added a regression test around that behavior.

### Testing done

- Ran `npm run build` in `frontend`
- Added a regression test in `frontend/src/tests/main.test.tsx` to verify:
  - the app mounts into `#chatbot-root`
  - a clear error is thrown if the expected root element is missing

I did not include screenshots for this one because the change is focused on the frontend mount point rather than a visible UI change. The behavior is covered by the regression test and the mount target is now aligned with the container rendered by the plugin footer.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
