### PR TITLE
refactor: update testing configuration handling in Makefile and loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ api: setup-backend run-api
 
 dev-lite: setup-backend
 	@echo "Starting API in lite mode..."
-	# Lite mode uses PYTEST_VERSION=1 to load the testing configuration,
+	# Lite mode uses APP_ENV=testing to load the testing configuration,
 	# which disables local LLM loading. This is useful for API development
 	# when you don't need to test actual chat completions.
-	@$(BACKEND_SHELL) && PYTEST_VERSION=1 uvicorn api.main:app --reload
+	@$(BACKEND_SHELL) && APP_ENV=testing uvicorn api.main:app --reload
 
 # TESTS
 

--- a/chatbot-core/api/config/loader.py
+++ b/chatbot-core/api/config/loader.py
@@ -21,7 +21,10 @@ def load_config():
     config_dev_path = os.path.join(file_dir, "config.yml")
     config_testing_path = os.path.join(file_dir, "config-testing.yml")
 
-    if os.environ.get("PYTEST_VERSION") is not None:
+    app_env = os.environ.get("APP_ENV", "").lower()
+    use_testing = app_env == "testing" or os.environ.get("PYTEST_VERSION") is not None
+
+    if use_testing:
         logger.info("#### Loading test configuration ####")
         config_path = config_testing_path
     else:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -243,13 +243,14 @@ For contributors who do not need local inference, a test configuration
 is available.
 
 The backend includes a `config-testing.yml` file that disables local
-LLM loading. This configuration is activated when the
-`PYTEST_VERSION` environment variable is set.
+LLM loading. This configuration is activated by setting `APP_ENV=testing`.
+For backward compatibility, setting `PYTEST_VERSION` (auto-set by pytest)
+also activates the testing configuration.
 
 Example:
 
 ```bash
-PYTEST_VERSION=1 make api
+APP_ENV=testing make api
 ```
 
 ## Common Troubleshooting


### PR DESCRIPTION
Fixes: https://github.com/jenkinsci/resources-ai-chatbot-plugin/issues/221

- Changed the environment variable from `PYTEST_VERSION` to `APP_ENV` for activating the testing configuration in the Makefile.
- Updated the loader to check for `APP_ENV` and maintain backward compatibility with `PYTEST_VERSION`.
- Revised documentation to reflect the new environment variable usage for starting the API in testing mode.

<!-- Please describe your pull request here. -->

### Testing done

- Verified that setting `APP_ENV=testing` correctly loads `config-testing.yml` via `make dev-lite`.
- Verified that `PYTEST_VERSION` (auto-set by pytest) still triggers the testing configuration for backward compatibility.
- Confirmed that without either variable set, `config.yml` (dev config) is loaded as expected.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md
You can override it by creating .github/pull_request_template.md in your own repository
-->
