### PR TITLE
docs(setup): note CORS hardening before production (#347)

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -252,6 +252,38 @@ Example:
 PYTEST_VERSION=1 make api
 ```
 
+## Production Hardening: CORS
+
+The shipped `chatbot-core/api/config/config.yml` sets:
+
+```yaml
+cors:
+  allowed_origins:
+    - "*"
+```
+
+The wildcard is intended for local development only. **Before exposing the
+API beyond `localhost`, restrict `allowed_origins` to the Jenkins instance
+origin(s) that should be allowed to call the chatbot API.**
+
+Leaving `*` in production allows any website a logged-in user visits to
+make cross-origin requests to the chatbot endpoints in that user's browser
+context (CSRF-style abuse, chat history exfiltration). This is OWASP
+[A05:2021 Security Misconfiguration](https://owasp.org/Top10/A05_2021-Security_Misconfiguration/).
+
+### Example
+
+Edit `chatbot-core/api/config/config.yml`:
+
+```yaml
+cors:
+  allowed_origins:
+    - "http://localhost:8080"        # local Jenkins
+    - "https://jenkins.example.com"  # production Jenkins origin
+```
+
+Restart the API after changing the config.
+
 ## Common Troubleshooting
 
 This section covers common issues encountered during setup, especially when installing


### PR DESCRIPTION
## Summary

- Fixes #347

Per maintainer guidance on #347, this is a **docs-only** patch.

The wildcard in `chatbot-core/api/config/config.yml` (`cors.allowed_origins: ["*"]`) is intentional for local dev, but operators have no in-repo signal that they should tighten it before deploying. This adds a short "Production Hardening: CORS" section to `docs/setup.md` covering:

- Why the wildcard ships as-is (dev convenience)
- Why it must be restricted before exposing the API beyond `localhost`
- A concrete `config.yml` example with `localhost:8080` + a production origin
- Reference to OWASP A05:2021

## Why docs only

In #347, @berviantoleo opted against changing the default and asked for this to live in the setup guide. So no code, no config, no env-var loader, no startup warning - just docs.

## Changes

- `docs/setup.md`: new "Production Hardening: CORS" section, placed right after the test-mode section so it sits with operational guidance.

## Verification

- `git diff --stat`: `1 file changed, 32 insertions(+)`
- No code or config files touched.
- Existing test commands and dev flow are unchanged.