### PR TITLE
fix: correct _extract_relevance_score return type annotation from str to int

### DIFF
--- a/chatbot-core/api/services/chat_service.py
+++ b/chatbot-core/api/services/chat_service.py
@@ -346,7 +346,7 @@ def _execute_search_tools(tool_calls) -> str:
     )
 
 
-def _get_query_context_relevance(query: str, context: str):
+def _get_query_context_relevance(query: str, context: str) -> int:
     """
     Returns the relevance of the retrieved context to the original query.
 
@@ -539,6 +539,12 @@ def _extract_relevance_score(response: str) -> int:
     """
     Extracts relevance score (0 or 1) from a response labeled with 'Label: N'; defaults to 0.
     The search is case-insensitive.
+
+    Args:
+        response (str): The LLM output containing a 'Label: N' pattern.
+
+    Returns:
+        int: 1 if the response is relevant, 0 otherwise.
     """
     match = re.search(r"Label:\s*([01])", response, re.IGNORECASE)
     if match:

--- a/chatbot-core/api/services/chat_service.py
+++ b/chatbot-core/api/services/chat_service.py
@@ -355,7 +355,7 @@ def _get_query_context_relevance(query: str, context: str):
         context (str): The retrieved context.
 
     Returns:
-        str: A relevance score or label as a string.
+        int: A relevance score (1 for relevant, 0 for not relevant).
     """
     prompt = CONTEXT_RELEVANCE_PROMPT.format(query=query, context=context)
 
@@ -535,18 +535,15 @@ def _extract_query_type(response: str) -> str:
     return ""
 
 
-def _extract_relevance_score(response: str) -> str:
+def _extract_relevance_score(response: str) -> int:
     """
     Extracts relevance score (0 or 1) from a response labeled with 'Label: N'; defaults to 0.
     The search is case-insensitive.
     """
     match = re.search(r"Label:\s*([01])", response, re.IGNORECASE)
     if match:
-        relevance_score = int(match.group(1))
-    else:
-        relevance_score = 0
-
-    return relevance_score
+        return int(match.group(1))
+    return 0
 
 def _generate_search_query_from_logs(log_text: str) -> str:
     """

--- a/chatbot-core/tests/unit/services/test_chat_service.py
+++ b/chatbot-core/tests/unit/services/test_chat_service.py
@@ -3,10 +3,7 @@
 import logging
 from unittest.mock import MagicMock
 import pytest
-from api.services.chat_service import (
-    generate_answer, get_chatbot_reply, retrieve_context,
-    _extract_relevance_score
-)
+from api.services.chat_service import generate_answer, get_chatbot_reply, retrieve_context
 from api.config.loader import CONFIG
 from api.models.schemas import ChatResponse, FileAttachment, FileType
 
@@ -370,33 +367,3 @@ def test_get_chatbot_reply_multiple_file_attachments(
 
     assert isinstance(response, ChatResponse)
     assert response.reply == "Multi-file reply"
-
-
-class TestExtractRelevanceScore:
-    """Tests for _extract_relevance_score return type and behavior."""
-
-    def test_returns_int_type(self):
-        """Return value must be int, not str."""
-        result = _extract_relevance_score("Label: 1")
-        assert isinstance(result, int)
-
-    def test_extracts_label_1(self):
-        """Should return 1 when response contains 'Label: 1'."""
-        assert _extract_relevance_score("Label: 1") == 1
-
-    def test_extracts_label_0(self):
-        """Should return 0 when response contains 'Label: 0'."""
-        assert _extract_relevance_score("Label: 0") == 0
-
-    def test_case_insensitive(self):
-        """Matching should be case-insensitive."""
-        assert _extract_relevance_score("label: 1") == 1
-        assert _extract_relevance_score("LABEL: 0") == 0
-
-    def test_defaults_to_zero_on_no_match(self):
-        """Should return 0 when no Label pattern is found."""
-        assert _extract_relevance_score("No label here") == 0
-
-    def test_defaults_to_zero_on_empty_string(self):
-        """Should return 0 for empty input."""
-        assert _extract_relevance_score("") == 0

--- a/chatbot-core/tests/unit/services/test_chat_service.py
+++ b/chatbot-core/tests/unit/services/test_chat_service.py
@@ -3,7 +3,10 @@
 import logging
 from unittest.mock import MagicMock
 import pytest
-from api.services.chat_service import generate_answer, get_chatbot_reply, retrieve_context
+from api.services.chat_service import (
+    generate_answer, get_chatbot_reply, retrieve_context,
+    _extract_relevance_score
+)
 from api.config.loader import CONFIG
 from api.models.schemas import ChatResponse, FileAttachment, FileType
 
@@ -367,3 +370,33 @@ def test_get_chatbot_reply_multiple_file_attachments(
 
     assert isinstance(response, ChatResponse)
     assert response.reply == "Multi-file reply"
+
+
+class TestExtractRelevanceScore:
+    """Tests for _extract_relevance_score return type and behavior."""
+
+    def test_returns_int_type(self):
+        """Return value must be int, not str."""
+        result = _extract_relevance_score("Label: 1")
+        assert isinstance(result, int)
+
+    def test_extracts_label_1(self):
+        """Should return 1 when response contains 'Label: 1'."""
+        assert _extract_relevance_score("Label: 1") == 1
+
+    def test_extracts_label_0(self):
+        """Should return 0 when response contains 'Label: 0'."""
+        assert _extract_relevance_score("Label: 0") == 0
+
+    def test_case_insensitive(self):
+        """Matching should be case-insensitive."""
+        assert _extract_relevance_score("label: 1") == 1
+        assert _extract_relevance_score("LABEL: 0") == 0
+
+    def test_defaults_to_zero_on_no_match(self):
+        """Should return 0 when no Label pattern is found."""
+        assert _extract_relevance_score("No label here") == 0
+
+    def test_defaults_to_zero_on_empty_string(self):
+        """Should return 0 for empty input."""
+        assert _extract_relevance_score("") == 0


### PR DESCRIPTION
## Summary

fixes #357

`_extract_relevance_score()` returns `int` (0 or 1) but was annotated as `-> str`. the caller `_get_query_context_relevance()` docstring also incorrectly documented `str` as the return type.

## Changes

### `chatbot-core/api/services/chat_service.py`
- fix return type annotation: `-> str` → `-> int` (line 538)
- fix `_get_query_context_relevance()` docstring: `str: A relevance score or label as a string` → `int: A relevance score (1 for relevant, 0 for not relevant)` (line 358)
- simplify function body with early return

### `chatbot-core/tests/unit/services/test_chat_service.py`
- add 6 tests for `_extract_relevance_score()`:
  - return type is `int` (not `str`)
  - Extracts `Label: 1` → `1`
  - Extracts `Label: 0` → `0`
  - case-insensitive matching
  - defaults to `0` on no match
  - defaults to `0` on empty string