### PR TITLE
Generate separate embedding indexes for plugins, docs, and discourse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: all api setup-backend build-frontend test run-data-pipeline clean
+.PHONY: all api setup-backend build-frontend test run-data-pipeline clean \
+	run-data-storage run-data-storage-plugins run-data-storage-docs run-data-storage-discourse
 
 BACKEND_SHELL = cd chatbot-core && . ./venv/bin/activate && export PYTHONPATH=$$(pwd)
 
@@ -127,11 +128,26 @@ run-data-chunking-stack: setup-backend
 run-data-chunking: run-data-chunking-docs run-data-chunking-plugins run-data-chunking-discourse run-data-chunking-stack
 
 ## EMBEDDING & STORAGE
+# One FAISS index per source — file naming ({source}_index.idx / {source}_metadata.pkl)
+# matches what rag/retriever/retriever_utils.load_vector_index expects and the
+# tool_names values in api/config/config.yml.
 
-run-data-storage: setup-backend
+run-data-storage-plugins: setup-backend
 	@$(BACKEND_SHELL) && \
-	echo "### EMBEDDING AND STORING THE CHUNKS ###" && \
-	python3 rag/vectorstore/store_embeddings.py
+	echo "### EMBEDDING AND STORING PLUGIN CHUNKS ###" && \
+	python3 rag/vectorstore/store_embeddings.py --source plugins
+
+run-data-storage-docs: setup-backend
+	@$(BACKEND_SHELL) && \
+	echo "### EMBEDDING AND STORING JENKINS DOCS CHUNKS ###" && \
+	python3 rag/vectorstore/store_embeddings.py --source docs
+
+run-data-storage-discourse: setup-backend
+	@$(BACKEND_SHELL) && \
+	echo "### EMBEDDING AND STORING DISCOURSE CHUNKS ###" && \
+	python3 rag/vectorstore/store_embeddings.py --source discourse
+
+run-data-storage: run-data-storage-plugins run-data-storage-docs run-data-storage-discourse
 
 
 run-pipeline-core: run-data-collection run-data-preprocessing run-data-chunking run-data-storage

--- a/chatbot-core/api/services/chat_service.py
+++ b/chatbot-core/api/services/chat_service.py
@@ -392,8 +392,9 @@ def _get_query_context_relevance(query: str, context: str) -> int:
 # pylint: disable=duplicate-code
 def retrieve_context(user_input: str) -> str:
     """
-    Retrieves the most relevant document chunks for a user query
-    and reconstructs them by replacing placeholder tokens with actual code blocks.
+    Retrieves the most relevant document chunks for a user query across every
+    configured source (plugins, jenkins docs, community threads, ...) and
+    reconstructs them by replacing placeholder tokens with actual code blocks.
 
     Args:
         user_input (str): The input query string.
@@ -408,38 +409,53 @@ def retrieve_context(user_input: str) -> str:
             "Dev mode enabled - skipping RAG retrieval. Build indices to enable full RAG.")
         return "Dev mode: RAG indices not built. This is a placeholder context for testing."
 
-    data_retrieved, _ = get_relevant_documents(
-        user_input,
-        EMBEDDING_MODEL,
-        logger=logger,
-        source_name="plugins",
-        top_k=retrieval_config["top_k"]
-    )
-    if not data_retrieved:
-        logger.warning(retrieval_config["empty_context_message"])
-        return "No context available."
+    # Pull the same set of sources the new-architecture tools use.
+    tool_names = CONFIG.get("tool_names")
+    if not tool_names:
+        raise ValueError("tool_names missing from config")
+
+    source_names = list(tool_names.values())
+    top_k = retrieval_config["top_k"]
 
     context_texts = []
-    for item in data_retrieved:
-        item_id = item.get("id", "")
-        text = item.get("chunk_text", "")
-        if not item_id:
-            logger.warning(
-                "Id of retrieved context not found. Skipping element.")
+    for source_name in source_names:
+        data_retrieved, _ = get_relevant_documents(
+            user_input,
+            EMBEDDING_MODEL,
+            logger=logger,
+            source_name=source_name,
+            top_k=top_k,
+        )
+        if not data_retrieved:
+            logger.info("No relevant chunks from source '%s'.", source_name)
             continue
-        if text:
+
+        for item in data_retrieved:
+            item_id = item.get("id", "")
+            text = item.get("chunk_text", "")
+            if not item_id:
+                logger.warning(
+                    "Id of retrieved context not found in source '%s'. Skipping element.",
+                    source_name,
+                )
+                continue
+            if not text:
+                logger.warning(
+                    "Text of chunk with ID %s (source '%s') is missing",
+                    item_id, source_name,
+                )
+                continue
+
             code_iter = iter(item.get("code_blocks", []))
             replace = make_placeholder_replacer(code_iter, item_id, logger)
             text = re.sub(CODE_BLOCK_PLACEHOLDER_PATTERN, replace, text)
+            context_texts.append(f"[Source: {source_name}]\n{text}")
 
-            context_texts.append(text)
-        else:
-            logger.warning("Text of chunk with ID %s is missing", item_id)
-    return (
-        "\n\n".join(context_texts)
-        if context_texts
-        else retrieval_config["empty_context_message"]
-    )
+    if not context_texts:
+        logger.warning(retrieval_config["empty_context_message"])
+        return retrieval_config["empty_context_message"]
+
+    return "\n\n".join(context_texts)
 
 
 def generate_answer(prompt: str, max_tokens: Optional[int] = None) -> str:

--- a/chatbot-core/api/services/chat_service.py
+++ b/chatbot-core/api/services/chat_service.py
@@ -35,6 +35,11 @@ logger = LoggerFactory.instance().get_logger("api")
 llm_config = CONFIG["llm"]
 retrieval_config = CONFIG["retrieval"]
 CODE_BLOCK_PLACEHOLDER_PATTERN = r"\[\[(?:CODE_BLOCK|CODE_SNIPPET)_(\d+)\]\]"
+SOURCE_TOP_K_CONFIG_KEYS = {
+    "plugins": "top_k_plugins",
+    "docs": "top_k_docs",
+    "discourse": "top_k_discourse",
+}
 
 LOG_ANALYSIS_PATTERN = re.compile(
     r"Here are the last \d+ characters of the log:\s*```\s*(.*?)\s*```\s*(.*)",
@@ -411,14 +416,16 @@ def retrieve_context(user_input: str) -> str:
 
     # Pull the same set of sources the new-architecture tools use.
     tool_names = CONFIG.get("tool_names")
-    if not tool_names:
+    if not isinstance(tool_names, dict) or not tool_names:
         raise ValueError("tool_names missing from config")
 
     source_names = list(tool_names.values())
-    top_k = retrieval_config["top_k"]
 
     context_texts = []
     for source_name in source_names:
+        top_k_config_key = SOURCE_TOP_K_CONFIG_KEYS.get(
+            source_name, "top_k")
+        top_k = retrieval_config[top_k_config_key]
         data_retrieved, _ = get_relevant_documents(
             user_input,
             EMBEDDING_MODEL,
@@ -432,13 +439,13 @@ def retrieve_context(user_input: str) -> str:
 
         for item in data_retrieved:
             item_id = item.get("id", "")
-            text = item.get("chunk_text", "")
             if not item_id:
                 logger.warning(
                     "Id of retrieved context not found in source '%s'. Skipping element.",
                     source_name,
                 )
                 continue
+            text = item.get("chunk_text", "")
             if not text:
                 logger.warning(
                     "Text of chunk with ID %s (source '%s') is missing",

--- a/chatbot-core/rag/embedding/embed_chunks.py
+++ b/chatbot-core/rag/embedding/embed_chunks.py
@@ -10,12 +10,14 @@ from .embedding_utils import load_embedding_model, embed_documents
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROCESSED_DIR = os.path.join(SCRIPT_DIR, "..", "..", "data", "processed")
 MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
-CHUNK_FILES = [
-    #"chunks_docs.json",
-    "chunks_plugin_docs.json",
-    #"chunks_discourse_docs.json",
-    #"chunks_stackoverflow_threads.json"
-]
+
+# Maps a source_name (matching CONFIG["tool_names"] values and the
+# {source_name}_index.idx files the retriever expects) to its chunk JSON file.
+SOURCE_CHUNK_FILES = {
+    "plugins": "chunks_plugin_docs.json",
+    "docs": "chunks_docs.json",
+    "discourse": "chunks_discourse_docs.json",
+}
 
 def load_chunks_from_file(path, logger):
     """Load JSON file and return data, with proper error handling."""
@@ -28,18 +30,19 @@ def load_chunks_from_file(path, logger):
         logger.error("JSON decode error in %s: %s", path, e)
     return []
 
-def collect_all_chunks(logger):
+def collect_all_chunks(logger, chunk_files):
     """
-    Load and aggregate chunks from all selected JSON files.
+    Load and aggregate chunks from the given JSON files.
 
     Args:
         logger (logging.Logger): Logger for warnings and file-level updates.
+        chunk_files (list[str]): Chunk JSON filenames inside PROCESSED_DIR.
 
     Returns:
         list[dict]: A combined list of all loaded chunks.
     """
     all_chunks = []
-    for file_name in CHUNK_FILES:
+    for file_name in chunk_files:
         path = os.path.join(PROCESSED_DIR, file_name)
         chunks = load_chunks_from_file(path, logger)
         if not chunks:
@@ -48,17 +51,21 @@ def collect_all_chunks(logger):
         all_chunks.extend(chunks)
     return all_chunks
 
-def embed_chunks(logger):
+def embed_chunks(logger, chunk_files=None):
     """
     Embed all loaded text chunks and return vectors and associated metadata.
 
     Args:
         logger (logging.Logger): Logger for progress updates.
+        chunk_files (list[str] | None): Chunk JSON filenames to embed. Defaults to
+            every file in SOURCE_CHUNK_FILES when not provided.
 
     Returns:
         tuple: (list[np.ndarray], list[dict]) - embeddings and structured metadata.
     """
-    chunks = collect_all_chunks(logger)
+    if chunk_files is None:
+        chunk_files = list(SOURCE_CHUNK_FILES.values())
+    chunks = collect_all_chunks(logger, chunk_files)
     logger.info("Collected %d chunks.", len(chunks))
     metadata = []
     for chunk in chunks:

--- a/chatbot-core/rag/vectorstore/store_embeddings.py
+++ b/chatbot-core/rag/vectorstore/store_embeddings.py
@@ -77,9 +77,14 @@ def run_indexing(nlist, nprobe, logger, source_name):
 
     if len(vectors) == 0:
         logger.warning(
-            "No vectors produced for source '%s' (chunk file: %s). Skipping index build.",
+            "No vectors produced for source '%s' (chunk file: %s). "
+            "Removing existing index and metadata.",
             source_name, chunk_file
         )
+        for path in (index_path, metadata_path):
+            if os.path.exists(path):
+                os.remove(path)
+                logger.info("Removed stale embedding output at %s", path)
         return
 
     vectors_np = np.array(vectors).astype("float32")

--- a/chatbot-core/rag/vectorstore/store_embeddings.py
+++ b/chatbot-core/rag/vectorstore/store_embeddings.py
@@ -3,16 +3,16 @@ Embeds document chunks, builds a FAISS IVF index,
 and stores both the index and associated metadata to disk.
 """
 
+import argparse
 import os
 import numpy as np
 import faiss
 from rag.embedding import embed_chunks
+from rag.embedding.embed_chunks import SOURCE_CHUNK_FILES
 from rag.vectorstore.vectorstore_utils import save_faiss_index, save_metadata
 from utils import LoggerFactory
 
 VECTOR_STORE_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "data", "embeddings")
-INDEX_PATH = os.path.join(VECTOR_STORE_DIR, "plugins_index.idx")
-METADATA_PATH = os.path.join(VECTOR_STORE_DIR, "plugins_metadata.pkl")
 
 N_LIST = 256
 N_PROBE = 20
@@ -51,32 +51,66 @@ def build_faiss_ivf_index(vectors, nlist, nprobe, logger):
     return index
 
 
-def run_indexing(nlist, nprobe, logger):
+def run_indexing(nlist, nprobe, logger, source_name):
     """
-    Main pipeline: embed documents, build FAISS index, and save index + metadata.
+    Main pipeline: embed documents for one source, build FAISS index,
+    and save index + metadata under {source_name}_index.idx / _metadata.pkl
+    so the retriever (which keys files by source_name) can load them.
 
     Args:
         nlist (int): Number of clusters for FAISS IVF index.
         nprobe (int): Number of clusters to search during queries.
+        source_name (str): Source key from SOURCE_CHUNK_FILES.
     """
-    logger.info("Starting document embedding...")
-    vectors, metadata = embed_chunks(logger)
+    if source_name not in SOURCE_CHUNK_FILES:
+        raise ValueError(
+            f"Unknown source '{source_name}'. "
+            f"Expected one of: {sorted(SOURCE_CHUNK_FILES)}"
+        )
+
+    chunk_file = SOURCE_CHUNK_FILES[source_name]
+    index_path = os.path.join(VECTOR_STORE_DIR, f"{source_name}_index.idx")
+    metadata_path = os.path.join(VECTOR_STORE_DIR, f"{source_name}_metadata.pkl")
+
+    logger.info("Starting document embedding for source '%s'...", source_name)
+    vectors, metadata = embed_chunks(logger, chunk_files=[chunk_file])
+
+    if len(vectors) == 0:
+        logger.warning(
+            "No vectors produced for source '%s' (chunk file: %s). Skipping index build.",
+            source_name, chunk_file
+        )
+        return
+
     vectors_np = np.array(vectors).astype("float32")
 
     index = build_faiss_ivf_index(vectors_np, nlist=nlist, nprobe=nprobe, logger=logger)
 
-    save_faiss_index(index, INDEX_PATH, logger)
-    save_metadata(metadata, METADATA_PATH, logger)
+    save_faiss_index(index, index_path, logger)
+    save_metadata(metadata, metadata_path, logger)
 
-    logger.info(f"Stored {len(vectors)} vectors to FAISS (IVFFlat) at {INDEX_PATH}")
+    logger.info("Stored %d vectors to FAISS (IVFFlat) at %s", len(vectors), index_path)
 
 
 def main():
     """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Build a FAISS index for one source (plugins, docs, discourse) "
+                    "or all of them if --source is omitted."
+    )
+    parser.add_argument(
+        "--source",
+        choices=sorted(SOURCE_CHUNK_FILES),
+        help="Source to index. If omitted, indexes every source in SOURCE_CHUNK_FILES.",
+    )
+    args = parser.parse_args()
+
     logger_factory = LoggerFactory.instance()
     logger = logger_factory.get_logger("embedding-storage")
 
-    run_indexing(nlist=N_LIST, nprobe=N_PROBE, logger=logger)
+    sources = [args.source] if args.source else list(SOURCE_CHUNK_FILES)
+    for source_name in sources:
+        run_indexing(nlist=N_LIST, nprobe=N_PROBE, logger=logger, source_name=source_name)
 
 if __name__ == "__main__":
     main()

--- a/chatbot-core/tests/integration/test_chatbot.py
+++ b/chatbot-core/tests/integration/test_chatbot.py
@@ -115,11 +115,7 @@ def test_multiple_messages_in_session(client, mock_llm_provider, mock_get_releva
     mock_llm_provider.generate.side_effect = [
         "Reply 1", "Reply 2", "Reply 3"
     ]
-    mock_get_relevant_documents.side_effect = [
-        get_relevant_documents_output(),
-        get_relevant_documents_output(),
-        get_relevant_documents_output()
-    ]
+    mock_get_relevant_documents.return_value = get_relevant_documents_output()
     session_id = client.post("/sessions").json()["session_id"]
     for i in range(3):
         resp = client.post(f"/sessions/{session_id}/message", json={"message": f"Msg {i+1}"})

--- a/chatbot-core/tests/unit/mocks/test_env.py
+++ b/chatbot-core/tests/unit/mocks/test_env.py
@@ -106,10 +106,14 @@ def mock_embed_documents(mocker):
 
 @pytest.fixture
 def patched_chunk_files(mocker):
-    """Fixture to patch CHUNK_FILES."""
+    """Patch source chunk file mappings."""
     return mocker.patch(
-        "rag.embedding.embed_chunks.CHUNK_FILES",
-        ["file1.json", "file2.json", "file3.json"]
+        "rag.embedding.embed_chunks.SOURCE_CHUNK_FILES",
+        {
+            "source1": "file1.json",
+            "source2": "file2.json",
+            "source3": "file3.json",
+        }
     )
 
 @pytest.fixture

--- a/chatbot-core/tests/unit/rag/embedding/test_embed_chunks.py
+++ b/chatbot-core/tests/unit/rag/embedding/test_embed_chunks.py
@@ -65,13 +65,12 @@ def test_embed_chunks_skips_invalid_chunks(mocker):
 
 def test_collect_all_chunks_with_custom_files(mocker):
     """Testing that collect_all_chunks aggregates chunks and logs warnings for empty files."""
-    patched_chunk_files = mocker.patch(
-        "rag.embedding.embed_chunks.CHUNK_FILES",
-        ["file1.json", "file2.json", "file3.json"]
-    )
-    mock_load_chunks_from_file = mocker.patch("rag.embedding.embed_chunks.load_chunks_from_file")
+    chunk_files = ["file1.json", "file2.json", "file3.json"]
 
-    _ = patched_chunk_files
+    mock_load_chunks_from_file = mocker.patch(
+        "rag.embedding.embed_chunks.load_chunks_from_file"
+    )
+
     mock_load_chunks_from_file.side_effect = [
         get_mock_chunks("valid"),
         get_mock_chunks("invalid"),
@@ -80,9 +79,12 @@ def test_collect_all_chunks_with_custom_files(mocker):
 
     mock_logger = mocker.Mock()
 
-    chunks = collect_all_chunks(mock_logger)
+    chunks = collect_all_chunks(mock_logger, chunk_files)
 
-    assert len(chunks) == (len(get_mock_chunks("valid")) + len(get_mock_chunks("invalid")))
+    assert len(chunks) == (
+        len(get_mock_chunks("valid"))
+        + len(get_mock_chunks("invalid"))
+    )
     assert mock_load_chunks_from_file.call_count == 3
     mock_logger.warning.assert_called_once_with(
         "No chunks available from %s.", "file3.json"

--- a/chatbot-core/tests/unit/rag/vectorstore/test_store_embeddings.py
+++ b/chatbot-core/tests/unit/rag/vectorstore/test_store_embeddings.py
@@ -143,3 +143,40 @@ def test_run_indexing_successful(
         mock_logger
     )
     assert mock_logger.info.call_count >= 1
+
+
+def test_run_indexing_removes_existing_outputs_when_no_vectors(mocker, tmp_path):
+    """Test run_indexing removes stale outputs when no vectors are produced."""
+    mock_logger = mocker.Mock()
+    index_path = tmp_path / "plugins_index.idx"
+    metadata_path = tmp_path / "plugins_metadata.pkl"
+    index_path.write_text("stale index", encoding="utf-8")
+    metadata_path.write_text("stale metadata", encoding="utf-8")
+
+    mocker.patch.object(store_embeddings, "VECTOR_STORE_DIR", str(tmp_path))
+    mocker.patch(
+        "rag.vectorstore.store_embeddings.embed_chunks",
+        return_value=([], [])
+    )
+    mock_build_index = mocker.patch(
+        "rag.vectorstore.store_embeddings.build_faiss_ivf_index"
+    )
+    mock_save_faiss_index = mocker.patch(
+        "rag.vectorstore.store_embeddings.save_faiss_index"
+    )
+    mock_save_metadata = mocker.patch(
+        "rag.vectorstore.store_embeddings.save_metadata"
+    )
+
+    store_embeddings.run_indexing(
+        nlist=4,
+        nprobe=2,
+        logger=mock_logger,
+        source_name="plugins"
+    )
+
+    assert not index_path.exists()
+    assert not metadata_path.exists()
+    mock_build_index.assert_not_called()
+    mock_save_faiss_index.assert_not_called()
+    mock_save_metadata.assert_not_called()

--- a/chatbot-core/tests/unit/rag/vectorstore/test_store_embeddings.py
+++ b/chatbot-core/tests/unit/rag/vectorstore/test_store_embeddings.py
@@ -1,7 +1,9 @@
 """Unit Tests for store_embeddings module."""
 
-import numpy as np
+import os
+
 import faiss
+import numpy as np
 import pytest
 from rag.vectorstore import store_embeddings
 
@@ -105,10 +107,14 @@ def test_run_indexing_successful(
     store_embeddings.run_indexing(
         nlist=4,
         nprobe=2,
-        logger=mock_logger
+        logger=mock_logger,
+        source_name="plugins"
     )
 
-    mock_embed_chunks.assert_called_once_with(mock_logger)
+    mock_embed_chunks.assert_called_once_with(
+        mock_logger,
+        chunk_files=["chunks_plugin_docs.json"]
+    )
     expected_vectors_np = np.array(vectors).astype("float32")
     mock_build_index.assert_called_once()
     np.testing.assert_array_equal(
@@ -118,14 +124,22 @@ def test_run_indexing_successful(
     assert mock_build_index.call_args[1]["nlist"] == 4
     assert mock_build_index.call_args[1]["nprobe"] == 2
     assert mock_build_index.call_args[1]["logger"] == mock_logger
+    expected_index_path = os.path.join(
+        store_embeddings.VECTOR_STORE_DIR,
+        "plugins_index.idx"
+    )
     mock_save_faiss_index.assert_called_once_with(
         mock_index,
-        store_embeddings.INDEX_PATH,
+        expected_index_path,
         mock_logger
+    )
+    expected_metadata_path = os.path.join(
+        store_embeddings.VECTOR_STORE_DIR,
+        "plugins_metadata.pkl"
     )
     mock_save_metadata.assert_called_once_with(
         metadata,
-        store_embeddings.METADATA_PATH,
+        expected_metadata_path,
         mock_logger
     )
     assert mock_logger.info.call_count >= 1

--- a/chatbot-core/tests/unit/services/test_chat_service.py
+++ b/chatbot-core/tests/unit/services/test_chat_service.py
@@ -11,6 +11,14 @@ from api.config.loader import CONFIG
 from api.models.schemas import ChatResponse, FileAttachment, FileType
 
 
+def expected_context_for_all_sources(text: str) -> str:
+    """Build expected context when each configured source returns the same text."""
+    return "\n\n".join(
+        f"[Source: {source_name}]\n{text}"
+        for source_name in CONFIG["tool_names"].values()
+    )
+
+
 def test_get_chatbot_reply_success(
     mock_get_session,
     mock_retrieve_context,
@@ -141,10 +149,11 @@ def test_retrieve_context_with_placeholders(mock_get_relevant_documents):
     assert document["code_blocks"][1] in result
     assert "[[CODE_BLOCK_0]]" not in result
     assert "[[CODE_SNIPPET_1]]" not in result
-    assert result == (
+    expected_text = (
         "Here is a code block: print('Hello, code block'), and here you have "
         "a code snippet: print('Hello, code snippet')"
     )
+    assert result == expected_context_for_all_sources(expected_text)
 
 
 def test_retrieve_context_no_documents(mock_get_relevant_documents):
@@ -179,7 +188,7 @@ def test_retrieve_context_missing_text(mock_get_relevant_documents, caplog):
         result = retrieve_context("Query with missing text")
 
     assert CONFIG["retrieval"]["empty_context_message"] == result
-    assert "Text of chunk with ID doc-111 is missing" in caplog.text
+    assert "Text of chunk with ID doc-111 (source 'plugins') is missing" in caplog.text
 
 
 def test_retrieve_context_with_missing_code(mock_get_relevant_documents, caplog):
@@ -195,9 +204,8 @@ def test_retrieve_context_with_missing_code(mock_get_relevant_documents, caplog)
 
     assert document["code_blocks"][0] in result
     assert "[MISSING_CODE]" in result
-    assert result == (
-        "Snippet 1: print('Only one snippet'), Snippet 2: [MISSING_CODE]"
-    )
+    expected_text = "Snippet 1: print('Only one snippet'), Snippet 2: [MISSING_CODE]"
+    assert result == expected_context_for_all_sources(expected_text)
     assert "More placeholders than code blocks in chunk with ID doc-111" in caplog.text
 
 


### PR DESCRIPTION
### Description

This PR fixes the embedding storage pipeline to support multiple knowledge sources.

Previously, `store_embeddings.py` used hardcoded output paths (`plugins_index.idx` and `plugins_metadata.pkl`), causing embedding runs for other sources to overwrite the same files. As a result, only the plugin index was generated and available to the retriever.

This change:

* Adds source-aware indexing using the `--source` argument.
* Generates source-specific FAISS indexes and metadata files.
* Supports the following sources:

  * `plugins`
  * `docs`
  * `discourse`
* Ensures generated filenames match the naming convention expected by the retriever (`{source}_index.idx` and `{source}_metadata.pkl`).
* Updates embedding generation to process only the chunk file associated with the requested source.

Fixes #376
Fixes #144

### Testing done

Manually tested locally by running the embedding storage pipeline and verifying that indexes and metadata files were generated for all supported sources.

Command executed:

```bash
make run-data-storage
```

Generated files:

```text
chatbot-core/data/embeddings
├── discourse_index.idx
├── discourse_metadata.pkl
├── docs_index.idx
├── docs_metadata.pkl
├── plugins_index.idx
└── plugins_metadata.pkl
```

Verified that:

* Plugin chunks generate `plugins_index.idx` and `plugins_metadata.pkl`
* Jenkins documentation chunks generate `docs_index.idx` and `docs_metadata.pkl`
* Community discussion chunks generate `discourse_index.idx` and `discourse_metadata.pkl`
* Output filenames align with the retriever's expected source naming convention

### Submitter checklist

* [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x] Ensure that the pull request title represents the desired changelog entry
* [x] Please describe what you did
* [x] Link to relevant issues in GitHub or Jira
* [x] Link to relevant pull requests, esp. upstream and downstream changes
* [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
