### PR TITLE
  Add GraphRAG schema and graph store foundation

### DIFF
--- a/chatbot-core/rag/graph/__init__.py
+++ b/chatbot-core/rag/graph/__init__.py
@@ -1,1 +1,1 @@
-"""GraphRAG helpers."""
+"""GraphRAG schema, model, and graph storage helpers."""

--- a/chatbot-core/rag/graph/__init__.py
+++ b/chatbot-core/rag/graph/__init__.py
@@ -1,0 +1,1 @@
+"""GraphRAG helpers."""

--- a/chatbot-core/rag/graph/graph_store.py
+++ b/chatbot-core/rag/graph/graph_store.py
@@ -1,0 +1,65 @@
+"""GraphRAG graph store helpers."""
+
+import json
+import os
+
+import networkx as nx
+from networkx.readwrite import json_graph
+
+
+GRAPH_STORE_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "data", "graph")
+DEFAULT_PLUGIN_GRAPH_PATH = os.path.join(GRAPH_STORE_DIR, "plugin_graph.json")
+
+
+def save_graph(graph: nx.MultiDiGraph, path: str, logger) -> None:
+    """
+    Save a MultiDiGraph to JSON.
+
+    Args:
+        graph (nx.MultiDiGraph): Graph to save.
+        path (str): File path to save the graph.
+        logger (logging.Logger): Logger for status or error messages.
+    """
+    if not isinstance(graph, nx.MultiDiGraph):
+        logger.error("Graph must be a NetworkX MultiDiGraph")
+        return
+
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        graph_data = json_graph.node_link_data(graph, edges="edges")
+        with open(path, "w", encoding="utf-8") as graph_file:
+            json.dump(graph_data, graph_file, indent=2)
+            graph_file.write("\n")
+        logger.info("Graph saved to %s", path)
+    except (OSError, TypeError, ValueError) as error:
+        logger.error("Failed to save graph to %s: %s", path, error)
+
+
+def load_graph(path: str, logger) -> nx.MultiDiGraph | None:
+    """
+    Load a MultiDiGraph from JSON.
+
+    Args:
+        path (str): File path to load the graph from.
+        logger (logging.Logger): Logger for status or error messages.
+
+    Returns:
+        nx.MultiDiGraph | None: Loaded graph, or None if loading fails.
+    """
+    try:
+        logger.info("Loading graph from %s...", path)
+        with open(path, encoding="utf-8") as graph_file:
+            graph_data = json.load(graph_file)
+        graph = json_graph.node_link_graph(graph_data, edges="edges")
+
+        if not isinstance(graph, nx.MultiDiGraph):
+            logger.error("Loaded graph is not a NetworkX MultiDiGraph: %s", path)
+            return None
+
+        logger.info("Graph loaded successfully.")
+        return graph
+    except FileNotFoundError as error:
+        logger.error("Graph file not found: %s - %s", path, error)
+    except (OSError, json.JSONDecodeError, TypeError, KeyError, ValueError) as error:
+        logger.error("Failed to load graph from %s - %s", path, error)
+    return None

--- a/chatbot-core/rag/graph/graph_store.py
+++ b/chatbot-core/rag/graph/graph_store.py
@@ -1,14 +1,14 @@
 """Save and load GraphRAG NetworkX graph artifacts."""
 
 import json
-import os
+from pathlib import Path
 
 import networkx as nx
 from networkx.readwrite import json_graph
 
 
-GRAPH_STORE_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "data", "graph")
-DEFAULT_PLUGIN_GRAPH_PATH = os.path.join(GRAPH_STORE_DIR, "plugin_graph.json")
+GRAPH_STORE_DIR = Path(__file__).resolve().parents[2] / "data" / "graph"
+DEFAULT_PLUGIN_GRAPH_PATH = GRAPH_STORE_DIR / "plugin_graph.json"
 
 
 def save_graph(graph: nx.MultiDiGraph, path: str, logger) -> None:
@@ -24,15 +24,17 @@ def save_graph(graph: nx.MultiDiGraph, path: str, logger) -> None:
         logger.error("Graph must be a NetworkX MultiDiGraph")
         return
 
+    graph_path = Path(path)
+
     try:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        graph_path.parent.mkdir(parents=True, exist_ok=True)
         graph_data = json_graph.node_link_data(graph, edges="edges")
-        with open(path, "w", encoding="utf-8") as graph_file:
+        with graph_path.open("w", encoding="utf-8") as graph_file:
             json.dump(graph_data, graph_file, indent=2)
             graph_file.write("\n")
-        logger.info("Graph saved to %s", path)
+        logger.info("Graph saved to %s", graph_path)
     except (OSError, TypeError, ValueError) as error:
-        logger.error("Failed to save graph to %s: %s", path, error)
+        logger.error("Failed to save graph to %s: %s", graph_path, error)
 
 
 def load_graph(path: str, logger) -> nx.MultiDiGraph | None:
@@ -47,20 +49,22 @@ def load_graph(path: str, logger) -> nx.MultiDiGraph | None:
         nx.MultiDiGraph | None: Loaded graph when parsing succeeds, otherwise
         None.
     """
+    graph_path = Path(path)
+
     try:
-        logger.info("Loading graph from %s...", path)
-        with open(path, encoding="utf-8") as graph_file:
+        logger.info("Loading graph from %s...", graph_path)
+        with graph_path.open(encoding="utf-8") as graph_file:
             graph_data = json.load(graph_file)
         graph = json_graph.node_link_graph(graph_data, edges="edges")
 
         if not isinstance(graph, nx.MultiDiGraph):
-            logger.error("Loaded graph is not a NetworkX MultiDiGraph: %s", path)
+            logger.error("Loaded graph is not a NetworkX MultiDiGraph: %s", graph_path)
             return None
 
         logger.info("Graph loaded successfully.")
         return graph
     except FileNotFoundError as error:
-        logger.error("Graph file not found: %s - %s", path, error)
+        logger.error("Graph file not found: %s - %s", graph_path, error)
     except (OSError, json.JSONDecodeError, TypeError, KeyError, ValueError) as error:
-        logger.error("Failed to load graph from %s - %s", path, error)
+        logger.error("Failed to load graph from %s - %s", graph_path, error)
     return None

--- a/chatbot-core/rag/graph/graph_store.py
+++ b/chatbot-core/rag/graph/graph_store.py
@@ -1,4 +1,4 @@
-"""GraphRAG graph store helpers."""
+"""Save and load GraphRAG NetworkX graph artifacts."""
 
 import json
 import os
@@ -13,12 +13,12 @@ DEFAULT_PLUGIN_GRAPH_PATH = os.path.join(GRAPH_STORE_DIR, "plugin_graph.json")
 
 def save_graph(graph: nx.MultiDiGraph, path: str, logger) -> None:
     """
-    Save a MultiDiGraph to JSON.
+    Save a NetworkX MultiDiGraph to node-link JSON.
 
     Args:
-        graph (nx.MultiDiGraph): Graph to save.
-        path (str): File path to save the graph.
-        logger (logging.Logger): Logger for status or error messages.
+        graph (nx.MultiDiGraph): Graph artifact to serialize.
+        path (str): Destination JSON file path.
+        logger (logging.Logger): Logger for save status or error messages.
     """
     if not isinstance(graph, nx.MultiDiGraph):
         logger.error("Graph must be a NetworkX MultiDiGraph")
@@ -37,14 +37,15 @@ def save_graph(graph: nx.MultiDiGraph, path: str, logger) -> None:
 
 def load_graph(path: str, logger) -> nx.MultiDiGraph | None:
     """
-    Load a MultiDiGraph from JSON.
+    Load a NetworkX MultiDiGraph from node-link JSON.
 
     Args:
-        path (str): File path to load the graph from.
-        logger (logging.Logger): Logger for status or error messages.
+        path (str): Source JSON file path.
+        logger (logging.Logger): Logger for load status or error messages.
 
     Returns:
-        nx.MultiDiGraph | None: Loaded graph, or None if loading fails.
+        nx.MultiDiGraph | None: Loaded graph when parsing succeeds, otherwise
+        None.
     """
     try:
         logger.info("Loading graph from %s...", path)

--- a/chatbot-core/rag/graph/models.py
+++ b/chatbot-core/rag/graph/models.py
@@ -1,4 +1,4 @@
-"""GraphRAG model objects."""
+"""Typed model objects for GraphRAG triples and retrieval results."""
 
 from dataclasses import dataclass, field
 
@@ -12,13 +12,31 @@ from rag.graph.schema import (
 
 
 def _require_non_empty(value: str, field_name: str) -> None:
-    """Check a string field is not empty."""
+    """
+    Require a string field to contain a non-whitespace value.
+
+    Args:
+        value (str): String value to validate.
+        field_name (str): Field name used in the error message.
+
+    Raises:
+        ValueError: If the value is empty or only whitespace.
+    """
     if not value or not value.strip():
         raise ValueError(f"{field_name} must not be empty")
 
 
 def _validate_relation_payload(relation: str, confidence: float) -> None:
-    """Check common relation fields."""
+    """
+    Validate relation type and confidence fields shared by graph models.
+
+    Args:
+        relation (str): Relation type value.
+        confidence (float): Relation confidence score.
+
+    Raises:
+        ValueError: If relation or confidence is invalid.
+    """
     if not is_valid_relation_type(relation):
         raise ValueError(f"invalid relation: {relation}")
     if not is_valid_confidence(confidence, DEFAULT_MIN_CONFIDENCE):
@@ -27,14 +45,26 @@ def _validate_relation_payload(relation: str, confidence: float) -> None:
 
 @dataclass(frozen=True)
 class GraphEntity:
-    """Entity used in graph data."""
+    """
+    Entity reference used by triples and graph relations.
+
+    Args:
+        name (str): Human-readable entity name.
+        entity_type (str): Entity type from the graph schema.
+        entity_id (str): Optional canonical graph node identifier.
+    """
 
     name: str
     entity_type: str
     entity_id: str = ""
 
     def __post_init__(self) -> None:
-        """Check entity fields."""
+        """
+        Validate entity fields after dataclass construction.
+
+        Raises:
+            ValueError: If the name is empty or the entity type is unsupported.
+        """
         _require_non_empty(self.name, "name")
         if not is_valid_entity_type(self.entity_type):
             raise ValueError(f"invalid entity_type: {self.entity_type}")
@@ -44,7 +74,15 @@ class GraphEntity:
 
 @dataclass(frozen=True)
 class GraphEvidence:
-    """Evidence from the source chunk."""
+    """
+    Source evidence attached to a graph relation.
+
+    Args:
+        source_chunk_id (str): Identifier of the source chunk.
+        source_title (str): Title attached to the source chunk.
+        source_data_source (str): Source collection name for the chunk.
+        evidence (str): Text evidence supporting the relation.
+    """
 
     source_chunk_id: str
     source_title: str
@@ -52,7 +90,12 @@ class GraphEvidence:
     evidence: str
 
     def __post_init__(self) -> None:
-        """Check evidence fields."""
+        """
+        Validate source evidence fields after dataclass construction.
+
+        Raises:
+            ValueError: If any required evidence value is missing or empty.
+        """
         evidence_payload = {
             "source_chunk_id": self.source_chunk_id,
             "source_title": self.source_title,
@@ -70,7 +113,16 @@ class GraphEvidence:
 
 @dataclass(frozen=True)
 class Triple:
-    """Raw graph triple found from a source chunk."""
+    """
+    Accepted source-grounded relation before graph storage.
+
+    Args:
+        source (GraphEntity): Source entity in the directed relation.
+        relation (str): Relation type from the graph schema.
+        target (GraphEntity): Target entity in the directed relation.
+        evidence (GraphEvidence): Source chunk evidence for the relation.
+        confidence (float): Confidence score for the relation.
+    """
 
     source: GraphEntity
     relation: str
@@ -79,13 +131,27 @@ class Triple:
     confidence: float
 
     def __post_init__(self) -> None:
-        """Check triple fields."""
+        """
+        Validate relation fields after dataclass construction.
+
+        Raises:
+            ValueError: If relation or confidence is invalid.
+        """
         _validate_relation_payload(self.relation, self.confidence)
 
 
 @dataclass(frozen=True)
 class GraphRelation:
-    """Relation returned from the graph."""
+    """
+    Relation returned from a graph traversal.
+
+    Args:
+        source (GraphEntity): Source graph node with a canonical entity ID.
+        relation (str): Relation type from the graph schema.
+        target (GraphEntity): Target graph node with a canonical entity ID.
+        evidence (GraphEvidence): Source chunk evidence for the relation.
+        confidence (float): Confidence score for the relation.
+    """
 
     source: GraphEntity
     relation: str
@@ -94,7 +160,12 @@ class GraphRelation:
     confidence: float
 
     def __post_init__(self) -> None:
-        """Check relation fields."""
+        """
+        Validate graph relation fields after dataclass construction.
+
+        Raises:
+            ValueError: If node IDs, relation, or confidence are invalid.
+        """
         _require_non_empty(self.source.entity_id, "source.entity_id")
         _require_non_empty(self.target.entity_id, "target.entity_id")
         _validate_relation_payload(self.relation, self.confidence)
@@ -102,7 +173,15 @@ class GraphRelation:
 
 @dataclass(frozen=True)
 class GraphRetrievalResult:
-    """Graph retrieval output."""
+    """
+    Result object returned by future graph retrieval code.
+
+    Args:
+        query_entity (str): Entity text detected in the user query.
+        matched_entity_id (str): Canonical graph node matched for the query.
+        relations (tuple[GraphRelation, ...]): Relations found by traversal.
+        traversal_depth (int): Traversal depth used to collect relations.
+    """
 
     query_entity: str
     matched_entity_id: str
@@ -110,7 +189,12 @@ class GraphRetrievalResult:
     traversal_depth: int = 1
 
     def __post_init__(self) -> None:
-        """Check retrieval result fields."""
+        """
+        Validate retrieval result fields after dataclass construction.
+
+        Raises:
+            ValueError: If entity fields are empty or traversal depth is invalid.
+        """
         _require_non_empty(self.query_entity, "query_entity")
         _require_non_empty(self.matched_entity_id, "matched_entity_id")
         if self.traversal_depth < 1:

--- a/chatbot-core/rag/graph/models.py
+++ b/chatbot-core/rag/graph/models.py
@@ -1,0 +1,119 @@
+"""GraphRAG model objects."""
+
+from dataclasses import dataclass, field
+
+from rag.graph.schema import (
+    DEFAULT_MIN_CONFIDENCE,
+    has_required_evidence_fields,
+    is_valid_confidence,
+    is_valid_entity_type,
+    is_valid_relation_type,
+)
+
+
+def _require_non_empty(value: str, field_name: str) -> None:
+    """Check a string field is not empty."""
+    if not value or not value.strip():
+        raise ValueError(f"{field_name} must not be empty")
+
+
+def _validate_relation_payload(relation: str, confidence: float) -> None:
+    """Check common relation fields."""
+    if not is_valid_relation_type(relation):
+        raise ValueError(f"invalid relation: {relation}")
+    if not is_valid_confidence(confidence, DEFAULT_MIN_CONFIDENCE):
+        raise ValueError(f"invalid confidence: {confidence}")
+
+
+@dataclass(frozen=True)
+class GraphEntity:
+    """Entity used in graph data."""
+
+    name: str
+    entity_type: str
+    entity_id: str = ""
+
+    def __post_init__(self) -> None:
+        """Check entity fields."""
+        _require_non_empty(self.name, "name")
+        if not is_valid_entity_type(self.entity_type):
+            raise ValueError(f"invalid entity_type: {self.entity_type}")
+        if self.entity_id:
+            _require_non_empty(self.entity_id, "entity_id")
+
+
+@dataclass(frozen=True)
+class GraphEvidence:
+    """Evidence from the source chunk."""
+
+    source_chunk_id: str
+    source_title: str
+    source_data_source: str
+    evidence: str
+
+    def __post_init__(self) -> None:
+        """Check evidence fields."""
+        evidence_payload = {
+            "source_chunk_id": self.source_chunk_id,
+            "source_title": self.source_title,
+            "source_data_source": self.source_data_source,
+            "evidence": self.evidence,
+        }
+        if not has_required_evidence_fields(evidence_payload):
+            raise ValueError("missing evidence fields")
+
+        _require_non_empty(self.source_chunk_id, "source_chunk_id")
+        _require_non_empty(self.source_title, "source_title")
+        _require_non_empty(self.source_data_source, "source_data_source")
+        _require_non_empty(self.evidence, "evidence")
+
+
+@dataclass(frozen=True)
+class Triple:
+    """Raw graph triple found from a source chunk."""
+
+    source: GraphEntity
+    relation: str
+    target: GraphEntity
+    evidence: GraphEvidence
+    confidence: float
+
+    def __post_init__(self) -> None:
+        """Check triple fields."""
+        _validate_relation_payload(self.relation, self.confidence)
+
+
+@dataclass(frozen=True)
+class GraphRelation:
+    """Relation returned from the graph."""
+
+    source: GraphEntity
+    relation: str
+    target: GraphEntity
+    evidence: GraphEvidence
+    confidence: float
+
+    def __post_init__(self) -> None:
+        """Check relation fields."""
+        _require_non_empty(self.source.entity_id, "source.entity_id")
+        _require_non_empty(self.target.entity_id, "target.entity_id")
+        _validate_relation_payload(self.relation, self.confidence)
+
+
+@dataclass(frozen=True)
+class GraphRetrievalResult:
+    """Graph retrieval output."""
+
+    query_entity: str
+    matched_entity_id: str
+    relations: tuple[GraphRelation, ...] = field(default_factory=tuple)
+    traversal_depth: int = 1
+
+    def __post_init__(self) -> None:
+        """Check retrieval result fields."""
+        _require_non_empty(self.query_entity, "query_entity")
+        _require_non_empty(self.matched_entity_id, "matched_entity_id")
+        if self.traversal_depth < 1:
+            raise ValueError("traversal_depth must be positive")
+        if not isinstance(self.relations, tuple):
+            object.__setattr__(self, "relations", tuple(self.relations))

--- a/chatbot-core/rag/graph/models.py
+++ b/chatbot-core/rag/graph/models.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 
 from rag.graph.schema import (
     DEFAULT_MIN_CONFIDENCE,
-    has_required_evidence_fields,
     is_valid_confidence,
     is_valid_entity_type,
     is_valid_relation_type,
@@ -96,15 +95,6 @@ class GraphEvidence:
         Raises:
             ValueError: If any required evidence value is missing or empty.
         """
-        evidence_payload = {
-            "source_chunk_id": self.source_chunk_id,
-            "source_title": self.source_title,
-            "source_data_source": self.source_data_source,
-            "evidence": self.evidence,
-        }
-        if not has_required_evidence_fields(evidence_payload):
-            raise ValueError("missing evidence fields")
-
         _require_non_empty(self.source_chunk_id, "source_chunk_id")
         _require_non_empty(self.source_title, "source_title")
         _require_non_empty(self.source_data_source, "source_data_source")

--- a/chatbot-core/rag/graph/schema.py
+++ b/chatbot-core/rag/graph/schema.py
@@ -42,14 +42,6 @@ REQUIRED_EVIDENCE_FIELDS = frozenset(
     }
 )
 
-REQUIRED_EDGE_FIELDS = frozenset(
-    {
-        *REQUIRED_EVIDENCE_FIELDS,
-        "relation",
-        "confidence",
-    }
-)
-
 ALLOWED_ENTITY_TYPES = frozenset(entity.value for entity in GraphEntityType)
 ALLOWED_RELATION_TYPES = frozenset(relation.value for relation in GraphRelationType)
 
@@ -113,16 +105,3 @@ def has_required_evidence_fields(evidence: dict) -> bool:
         bool: True when all required evidence fields are present.
     """
     return REQUIRED_EVIDENCE_FIELDS.issubset(evidence)
-
-
-def has_required_edge_fields(edge_data: dict) -> bool:
-    """
-    Check whether serialized edge data contains relation and evidence fields.
-
-    Args:
-        edge_data (dict): Serialized graph edge payload to validate.
-
-    Returns:
-        bool: True when all required edge fields are present.
-    """
-    return REQUIRED_EDGE_FIELDS.issubset(edge_data)

--- a/chatbot-core/rag/graph/schema.py
+++ b/chatbot-core/rag/graph/schema.py
@@ -1,10 +1,12 @@
-"""GraphRAG schema definitions."""
+"""GraphRAG schema definitions for plugin ecosystem relation artifacts."""
 
 from enum import Enum
 
 
 class GraphEntityType(str, Enum):
-    """Entity types we support in the graph."""
+    """
+    Entity types allowed in plugin ecosystem graph artifacts.
+    """
 
     PLUGIN = "Plugin"
     PLUGIN_VERSION = "PluginVersion"
@@ -14,7 +16,9 @@ class GraphEntityType(str, Enum):
 
 
 class GraphRelationType(str, Enum):
-    """Relation types we support in the graph."""
+    """
+    Directed relation types allowed between graph entities.
+    """
 
     DEPENDS_ON = "DEPENDS_ON"
     OPTIONAL_DEPENDS_ON = "OPTIONAL_DEPENDS_ON"
@@ -51,12 +55,28 @@ ALLOWED_RELATION_TYPES = frozenset(relation.value for relation in GraphRelationT
 
 
 def is_valid_entity_type(entity_type: str) -> bool:
-    """Check if this is a known entity type."""
+    """
+    Check whether a string is an allowed graph entity type.
+
+    Args:
+        entity_type (str): Entity type value to validate.
+
+    Returns:
+        bool: True when the entity type is supported, False otherwise.
+    """
     return entity_type in ALLOWED_ENTITY_TYPES
 
 
 def is_valid_relation_type(relation_type: str) -> bool:
-    """Check if this is a known relation type."""
+    """
+    Check whether a string is an allowed graph relation type.
+
+    Args:
+        relation_type (str): Relation type value to validate.
+
+    Returns:
+        bool: True when the relation type is supported, False otherwise.
+    """
     return relation_type in ALLOWED_RELATION_TYPES
 
 
@@ -64,7 +84,16 @@ def is_valid_confidence(
     confidence: float,
     min_confidence: float = DEFAULT_MIN_CONFIDENCE,
 ) -> bool:
-    """Check if confidence is good enough."""
+    """
+    Check whether a confidence score is within range and above threshold.
+
+    Args:
+        confidence (float): Confidence score to validate.
+        min_confidence (float): Minimum accepted confidence score.
+
+    Returns:
+        bool: True when the confidence score is accepted, False otherwise.
+    """
     return (
         MIN_RELATION_CONFIDENCE
         <= confidence
@@ -74,10 +103,26 @@ def is_valid_confidence(
 
 
 def has_required_evidence_fields(evidence: dict) -> bool:
-    """Check if evidence has the fields we need."""
+    """
+    Check whether graph evidence contains the required source fields.
+
+    Args:
+        evidence (dict): Evidence payload to validate.
+
+    Returns:
+        bool: True when all required evidence fields are present.
+    """
     return REQUIRED_EVIDENCE_FIELDS.issubset(evidence)
 
 
 def has_required_edge_fields(edge_data: dict) -> bool:
-    """Check if edge data has the fields we need."""
+    """
+    Check whether serialized edge data contains relation and evidence fields.
+
+    Args:
+        edge_data (dict): Serialized graph edge payload to validate.
+
+    Returns:
+        bool: True when all required edge fields are present.
+    """
     return REQUIRED_EDGE_FIELDS.issubset(edge_data)

--- a/chatbot-core/rag/graph/schema.py
+++ b/chatbot-core/rag/graph/schema.py
@@ -1,0 +1,83 @@
+"""GraphRAG schema definitions."""
+
+from enum import Enum
+
+
+class GraphEntityType(str, Enum):
+    """Entity types we support in the graph."""
+
+    PLUGIN = "Plugin"
+    PLUGIN_VERSION = "PluginVersion"
+    CVE = "CVE"
+    CONFIGURATION = "Configuration"
+    ERROR = "Error"
+
+
+class GraphRelationType(str, Enum):
+    """Relation types we support in the graph."""
+
+    DEPENDS_ON = "DEPENDS_ON"
+    OPTIONAL_DEPENDS_ON = "OPTIONAL_DEPENDS_ON"
+    CONFLICTS_WITH = "CONFLICTS_WITH"
+    FIXED_IN = "FIXED_IN"
+    CAUSES = "CAUSES"
+    RESOLVES = "RESOLVES"
+    MENTIONS = "MENTIONS"
+
+
+MIN_RELATION_CONFIDENCE = 0.0
+MAX_RELATION_CONFIDENCE = 1.0
+DEFAULT_MIN_CONFIDENCE = 0.5
+
+REQUIRED_EVIDENCE_FIELDS = frozenset(
+    {
+        "source_chunk_id",
+        "source_title",
+        "source_data_source",
+        "evidence",
+    }
+)
+
+REQUIRED_EDGE_FIELDS = frozenset(
+    {
+        *REQUIRED_EVIDENCE_FIELDS,
+        "relation",
+        "confidence",
+    }
+)
+
+ALLOWED_ENTITY_TYPES = frozenset(entity.value for entity in GraphEntityType)
+ALLOWED_RELATION_TYPES = frozenset(relation.value for relation in GraphRelationType)
+
+
+def is_valid_entity_type(entity_type: str) -> bool:
+    """Check if this is a known entity type."""
+    return entity_type in ALLOWED_ENTITY_TYPES
+
+
+def is_valid_relation_type(relation_type: str) -> bool:
+    """Check if this is a known relation type."""
+    return relation_type in ALLOWED_RELATION_TYPES
+
+
+def is_valid_confidence(
+    confidence: float,
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+) -> bool:
+    """Check if confidence is good enough."""
+    return (
+        MIN_RELATION_CONFIDENCE
+        <= confidence
+        <= MAX_RELATION_CONFIDENCE
+        and confidence >= min_confidence
+    )
+
+
+def has_required_evidence_fields(evidence: dict) -> bool:
+    """Check if evidence has the fields we need."""
+    return REQUIRED_EVIDENCE_FIELDS.issubset(evidence)
+
+
+def has_required_edge_fields(edge_data: dict) -> bool:
+    """Check if edge data has the fields we need."""
+    return REQUIRED_EDGE_FIELDS.issubset(edge_data)

--- a/chatbot-core/tests/unit/rag/graph/test_graph_store.py
+++ b/chatbot-core/tests/unit/rag/graph/test_graph_store.py
@@ -9,7 +9,12 @@ from rag.graph.schema import GraphRelationType
 
 
 def build_test_graph():
-    """Build a graph with parallel evidence edges."""
+    """
+    Build a MultiDiGraph with two parallel plugin relation edges.
+
+    Returns:
+        nx.MultiDiGraph: Test graph with node attributes and edge evidence.
+    """
     graph = nx.MultiDiGraph()
     graph.add_node("blueocean", name="Blue Ocean", entity_type="Plugin")
     graph.add_node("git", name="Git plugin", entity_type="Plugin")
@@ -37,7 +42,9 @@ def build_test_graph():
 
 
 def test_save_and_load_graph_preserves_multidigraph(tmp_path):
-    """Test graph save and load."""
+    """
+    Verify saved graph JSON loads back as a MultiDiGraph with node metadata.
+    """
     mock_logger = Mock()
     path = tmp_path / "plugin_graph.json"
 
@@ -50,7 +57,9 @@ def test_save_and_load_graph_preserves_multidigraph(tmp_path):
 
 
 def test_save_and_load_graph_preserves_parallel_edges(tmp_path):
-    """Test parallel edges survive JSON round trip."""
+    """
+    Verify parallel relation edges survive the node-link JSON round trip.
+    """
     mock_logger = Mock()
     path = tmp_path / "plugin_graph.json"
 
@@ -69,7 +78,9 @@ def test_save_and_load_graph_preserves_parallel_edges(tmp_path):
 
 
 def test_save_graph_rejects_plain_digraph(tmp_path):
-    """Test plain DiGraph is not saved."""
+    """
+    Verify the store rejects plain DiGraph instances.
+    """
     mock_logger = Mock()
     path = tmp_path / "plugin_graph.json"
 
@@ -80,7 +91,9 @@ def test_save_graph_rejects_plain_digraph(tmp_path):
 
 
 def test_load_graph_missing_file_returns_none(tmp_path):
-    """Test missing graph file."""
+    """
+    Verify loading a missing graph file returns None and logs an error.
+    """
     mock_logger = Mock()
     path = tmp_path / "missing_graph.json"
 
@@ -92,7 +105,9 @@ def test_load_graph_missing_file_returns_none(tmp_path):
 
 
 def test_load_graph_corrupt_json_returns_none(tmp_path):
-    """Test corrupt graph JSON."""
+    """
+    Verify loading malformed graph JSON returns None and logs an error.
+    """
     mock_logger = Mock()
     path = tmp_path / "plugin_graph.json"
     path.write_text("not json", encoding="utf-8")

--- a/chatbot-core/tests/unit/rag/graph/test_graph_store.py
+++ b/chatbot-core/tests/unit/rag/graph/test_graph_store.py
@@ -1,0 +1,104 @@
+"""Unit tests for GraphRAG graph store."""
+
+from unittest.mock import Mock
+
+import networkx as nx
+
+from rag.graph.graph_store import load_graph, save_graph
+from rag.graph.schema import GraphRelationType
+
+
+def build_test_graph():
+    """Build a graph with parallel evidence edges."""
+    graph = nx.MultiDiGraph()
+    graph.add_node("blueocean", name="Blue Ocean", entity_type="Plugin")
+    graph.add_node("git", name="Git plugin", entity_type="Plugin")
+    graph.add_edge(
+        "blueocean",
+        "git",
+        relation=GraphRelationType.DEPENDS_ON.value,
+        source_chunk_id="chunk-1",
+        source_title="Blue Ocean",
+        source_data_source="plugins",
+        evidence="Blue Ocean depends on Git.",
+        confidence=0.9,
+    )
+    graph.add_edge(
+        "blueocean",
+        "git",
+        relation=GraphRelationType.OPTIONAL_DEPENDS_ON.value,
+        source_chunk_id="chunk-2",
+        source_title="Blue Ocean",
+        source_data_source="plugins",
+        evidence="Git is optional in this setup.",
+        confidence=0.7,
+    )
+    return graph
+
+
+def test_save_and_load_graph_preserves_multidigraph(tmp_path):
+    """Test graph save and load."""
+    mock_logger = Mock()
+    path = tmp_path / "plugin_graph.json"
+
+    save_graph(build_test_graph(), str(path), mock_logger)
+    result = load_graph(str(path), mock_logger)
+
+    assert isinstance(result, nx.MultiDiGraph)
+    assert result.number_of_nodes() == 2
+    assert result.nodes["blueocean"]["name"] == "Blue Ocean"
+
+
+def test_save_and_load_graph_preserves_parallel_edges(tmp_path):
+    """Test parallel edges survive JSON round trip."""
+    mock_logger = Mock()
+    path = tmp_path / "plugin_graph.json"
+
+    save_graph(build_test_graph(), str(path), mock_logger)
+    result = load_graph(str(path), mock_logger)
+
+    assert result.number_of_edges("blueocean", "git") == 2
+    edge_data = result.get_edge_data("blueocean", "git")
+    relations = sorted(edge["relation"] for edge in edge_data.values())
+    assert relations == [
+        GraphRelationType.DEPENDS_ON.value,
+        GraphRelationType.OPTIONAL_DEPENDS_ON.value,
+    ]
+    assert edge_data[0]["source_chunk_id"] == "chunk-1"
+    assert edge_data[1]["source_chunk_id"] == "chunk-2"
+
+
+def test_save_graph_rejects_plain_digraph(tmp_path):
+    """Test plain DiGraph is not saved."""
+    mock_logger = Mock()
+    path = tmp_path / "plugin_graph.json"
+
+    save_graph(nx.DiGraph(), str(path), mock_logger)
+
+    assert not path.exists()
+    mock_logger.error.assert_called_once_with("Graph must be a NetworkX MultiDiGraph")
+
+
+def test_load_graph_missing_file_returns_none(tmp_path):
+    """Test missing graph file."""
+    mock_logger = Mock()
+    path = tmp_path / "missing_graph.json"
+
+    result = load_graph(str(path), mock_logger)
+
+    assert result is None
+    mock_logger.error.assert_called_once()
+    assert "Graph file not found" in mock_logger.error.call_args[0][0]
+
+
+def test_load_graph_corrupt_json_returns_none(tmp_path):
+    """Test corrupt graph JSON."""
+    mock_logger = Mock()
+    path = tmp_path / "plugin_graph.json"
+    path.write_text("not json", encoding="utf-8")
+
+    result = load_graph(str(path), mock_logger)
+
+    assert result is None
+    mock_logger.error.assert_called_once()
+    assert "Failed to load graph" in mock_logger.error.call_args[0][0]

--- a/chatbot-core/tests/unit/rag/graph/test_models.py
+++ b/chatbot-core/tests/unit/rag/graph/test_models.py
@@ -1,0 +1,104 @@
+"""Unit tests for GraphRAG models."""
+
+import pytest
+
+from rag.graph.models import (
+    GraphEntity,
+    GraphEvidence,
+    GraphRelation,
+    GraphRetrievalResult,
+    Triple,
+)
+from rag.graph.schema import GraphEntityType, GraphRelationType
+
+
+def build_entity(name="Git plugin", entity_id="git"):
+    """Build a test graph entity."""
+    return GraphEntity(
+        name=name,
+        entity_type=GraphEntityType.PLUGIN.value,
+        entity_id=entity_id,
+    )
+
+
+def build_evidence():
+    """Build test graph evidence."""
+    return GraphEvidence(
+        source_chunk_id="chunk-1",
+        source_title="Git plugin",
+        source_data_source="plugins",
+        evidence="Git plugin is mentioned in this chunk.",
+    )
+
+
+def test_triple_accepts_valid_payload():
+    """Test valid triple."""
+    triple = Triple(
+        source=build_entity("Blue Ocean", ""),
+        relation=GraphRelationType.DEPENDS_ON.value,
+        target=build_entity("Git plugin", ""),
+        evidence=build_evidence(),
+        confidence=0.9,
+    )
+
+    assert triple.relation == GraphRelationType.DEPENDS_ON.value
+
+
+def test_triple_rejects_invalid_relation():
+    """Test invalid triple relation."""
+    with pytest.raises(ValueError, match="invalid relation"):
+        Triple(
+            source=build_entity("Blue Ocean", ""),
+            relation="USES",
+            target=build_entity("Git plugin", ""),
+            evidence=build_evidence(),
+            confidence=0.9,
+        )
+
+
+def test_entity_rejects_empty_name():
+    """Test empty entity name."""
+    with pytest.raises(ValueError, match="name must not be empty"):
+        GraphEntity(name="", entity_type=GraphEntityType.PLUGIN.value)
+
+
+def test_evidence_rejects_empty_text():
+    """Test empty evidence text."""
+    with pytest.raises(ValueError, match="evidence must not be empty"):
+        GraphEvidence(
+            source_chunk_id="chunk-1",
+            source_title="Git plugin",
+            source_data_source="plugins",
+            evidence="",
+        )
+
+
+def test_graph_relation_requires_node_ids():
+    """Test relation needs graph node ids."""
+    with pytest.raises(ValueError, match="source.entity_id must not be empty"):
+        GraphRelation(
+            source=build_entity("Blue Ocean", ""),
+            relation=GraphRelationType.DEPENDS_ON.value,
+            target=build_entity("Git plugin", "git"),
+            evidence=build_evidence(),
+            confidence=0.9,
+        )
+
+
+def test_retrieval_result_converts_relations_to_tuple():
+    """Test retrieval relation tuple conversion."""
+    relation = GraphRelation(
+        source=build_entity("Blue Ocean", "blueocean"),
+        relation=GraphRelationType.DEPENDS_ON.value,
+        target=build_entity("Git plugin", "git"),
+        evidence=build_evidence(),
+        confidence=0.9,
+    )
+
+    result = GraphRetrievalResult(
+        query_entity="Blue Ocean",
+        matched_entity_id="blueocean",
+        relations=[relation],
+    )
+
+    assert result.relations == (relation,)

--- a/chatbot-core/tests/unit/rag/graph/test_models.py
+++ b/chatbot-core/tests/unit/rag/graph/test_models.py
@@ -13,7 +13,16 @@ from rag.graph.schema import GraphEntityType, GraphRelationType
 
 
 def build_entity(name="Git plugin", entity_id="git"):
-    """Build a test graph entity."""
+    """
+    Build a plugin entity for model tests.
+
+    Args:
+        name (str): Entity display name.
+        entity_id (str): Canonical graph node ID.
+
+    Returns:
+        GraphEntity: Test graph entity.
+    """
     return GraphEntity(
         name=name,
         entity_type=GraphEntityType.PLUGIN.value,
@@ -22,7 +31,12 @@ def build_entity(name="Git plugin", entity_id="git"):
 
 
 def build_evidence():
-    """Build test graph evidence."""
+    """
+    Build source evidence for model tests.
+
+    Returns:
+        GraphEvidence: Test graph evidence.
+    """
     return GraphEvidence(
         source_chunk_id="chunk-1",
         source_title="Git plugin",
@@ -32,7 +46,9 @@ def build_evidence():
 
 
 def test_triple_accepts_valid_payload():
-    """Test valid triple."""
+    """
+    Verify a valid triple can be constructed.
+    """
     triple = Triple(
         source=build_entity("Blue Ocean", ""),
         relation=GraphRelationType.DEPENDS_ON.value,
@@ -45,7 +61,9 @@ def test_triple_accepts_valid_payload():
 
 
 def test_triple_rejects_invalid_relation():
-    """Test invalid triple relation."""
+    """
+    Verify triple construction rejects unsupported relation values.
+    """
     with pytest.raises(ValueError, match="invalid relation"):
         Triple(
             source=build_entity("Blue Ocean", ""),
@@ -57,13 +75,17 @@ def test_triple_rejects_invalid_relation():
 
 
 def test_entity_rejects_empty_name():
-    """Test empty entity name."""
+    """
+    Verify graph entities require a non-empty name.
+    """
     with pytest.raises(ValueError, match="name must not be empty"):
         GraphEntity(name="", entity_type=GraphEntityType.PLUGIN.value)
 
 
 def test_evidence_rejects_empty_text():
-    """Test empty evidence text."""
+    """
+    Verify graph evidence requires non-empty evidence text.
+    """
     with pytest.raises(ValueError, match="evidence must not be empty"):
         GraphEvidence(
             source_chunk_id="chunk-1",
@@ -74,7 +96,9 @@ def test_evidence_rejects_empty_text():
 
 
 def test_graph_relation_requires_node_ids():
-    """Test relation needs graph node ids."""
+    """
+    Verify graph relations require canonical source and target node IDs.
+    """
     with pytest.raises(ValueError, match="source.entity_id must not be empty"):
         GraphRelation(
             source=build_entity("Blue Ocean", ""),
@@ -86,7 +110,9 @@ def test_graph_relation_requires_node_ids():
 
 
 def test_retrieval_result_converts_relations_to_tuple():
-    """Test retrieval relation tuple conversion."""
+    """
+    Verify retrieval results normalize relation collections to tuples.
+    """
     relation = GraphRelation(
         source=build_entity("Blue Ocean", "blueocean"),
         relation=GraphRelationType.DEPENDS_ON.value,

--- a/chatbot-core/tests/unit/rag/graph/test_schema.py
+++ b/chatbot-core/tests/unit/rag/graph/test_schema.py
@@ -12,27 +12,37 @@ from rag.graph.schema import (
 
 
 def test_valid_entity_type():
-    """Test known entity type."""
+    """
+    Verify that a schema-defined entity type is accepted.
+    """
     assert is_valid_entity_type(GraphEntityType.PLUGIN.value)
 
 
 def test_invalid_entity_type():
-    """Test unknown entity type."""
+    """
+    Verify that an unknown entity type is rejected.
+    """
     assert not is_valid_entity_type("Unknown")
 
 
 def test_valid_relation_type():
-    """Test known relation type."""
+    """
+    Verify that a schema-defined relation type is accepted.
+    """
     assert is_valid_relation_type(GraphRelationType.DEPENDS_ON.value)
 
 
 def test_invalid_relation_type():
-    """Test unknown relation type."""
+    """
+    Verify that an unknown relation type is rejected.
+    """
     assert not is_valid_relation_type("USES")
 
 
 def test_confidence_must_be_in_range_and_above_threshold():
-    """Test confidence range checks."""
+    """
+    Verify confidence must be within range and above the default threshold.
+    """
     assert is_valid_confidence(0.7)
     assert not is_valid_confidence(0.4)
     assert not is_valid_confidence(-0.1)
@@ -40,7 +50,9 @@ def test_confidence_must_be_in_range_and_above_threshold():
 
 
 def test_required_evidence_fields():
-    """Test evidence field check."""
+    """
+    Verify evidence payloads with all required fields are accepted.
+    """
     evidence = {
         "source_chunk_id": "chunk-1",
         "source_title": "Git plugin",
@@ -51,7 +63,9 @@ def test_required_evidence_fields():
 
 
 def test_required_edge_fields():
-    """Test edge field check."""
+    """
+    Verify edge payloads include relation metadata and evidence fields.
+    """
     edge_data = {
         "source_chunk_id": "chunk-1",
         "source_title": "Git plugin",

--- a/chatbot-core/tests/unit/rag/graph/test_schema.py
+++ b/chatbot-core/tests/unit/rag/graph/test_schema.py
@@ -1,0 +1,63 @@
+"""Unit tests for GraphRAG schema."""
+
+from rag.graph.schema import (
+    GraphEntityType,
+    GraphRelationType,
+    has_required_edge_fields,
+    has_required_evidence_fields,
+    is_valid_confidence,
+    is_valid_entity_type,
+    is_valid_relation_type,
+)
+
+
+def test_valid_entity_type():
+    """Test known entity type."""
+    assert is_valid_entity_type(GraphEntityType.PLUGIN.value)
+
+
+def test_invalid_entity_type():
+    """Test unknown entity type."""
+    assert not is_valid_entity_type("Unknown")
+
+
+def test_valid_relation_type():
+    """Test known relation type."""
+    assert is_valid_relation_type(GraphRelationType.DEPENDS_ON.value)
+
+
+def test_invalid_relation_type():
+    """Test unknown relation type."""
+    assert not is_valid_relation_type("USES")
+
+
+def test_confidence_must_be_in_range_and_above_threshold():
+    """Test confidence range checks."""
+    assert is_valid_confidence(0.7)
+    assert not is_valid_confidence(0.4)
+    assert not is_valid_confidence(-0.1)
+    assert not is_valid_confidence(1.1)
+
+
+def test_required_evidence_fields():
+    """Test evidence field check."""
+    evidence = {
+        "source_chunk_id": "chunk-1",
+        "source_title": "Git plugin",
+        "source_data_source": "plugins",
+        "evidence": "Git plugin is mentioned.",
+    }
+    assert has_required_evidence_fields(evidence)
+
+
+def test_required_edge_fields():
+    """Test edge field check."""
+    edge_data = {
+        "source_chunk_id": "chunk-1",
+        "source_title": "Git plugin",
+        "source_data_source": "plugins",
+        "evidence": "Git plugin is mentioned.",
+        "relation": GraphRelationType.MENTIONS.value,
+        "confidence": 0.8,
+    }
+    assert has_required_edge_fields(edge_data)

--- a/chatbot-core/tests/unit/rag/graph/test_schema.py
+++ b/chatbot-core/tests/unit/rag/graph/test_schema.py
@@ -3,7 +3,6 @@
 from rag.graph.schema import (
     GraphEntityType,
     GraphRelationType,
-    has_required_edge_fields,
     has_required_evidence_fields,
     is_valid_confidence,
     is_valid_entity_type,
@@ -60,18 +59,3 @@ def test_required_evidence_fields():
         "evidence": "Git plugin is mentioned.",
     }
     assert has_required_evidence_fields(evidence)
-
-
-def test_required_edge_fields():
-    """
-    Verify edge payloads include relation metadata and evidence fields.
-    """
-    edge_data = {
-        "source_chunk_id": "chunk-1",
-        "source_title": "Git plugin",
-        "source_data_source": "plugins",
-        "evidence": "Git plugin is mentioned.",
-        "relation": GraphRelationType.MENTIONS.value,
-        "confidence": 0.8,
-    }
-    assert has_required_edge_fields(edge_data)


### PR DESCRIPTION
Add GraphRAG schema and graph store foundation

This PR adds the GraphRAG foundation for plugin ecosystem queries.

It introduces a small `chatbot-core/rag/graph/` package with schema definitions, typed graph models, and graph persistence helpers built on `networkx.MultiDiGraph`. It also adds focused unit tests for schema validation, model validation, and graph save/load 

This PR is foundation-only. It does not add extraction, graph building, retrieval, runtime wiring, pipeline targets, data artifacts, or evaluation changes.

  ### Submitter checklist

  - [x] Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!
  - [x] Ensure that the pull request title represents the desired changelog entry
  - [x] Please describe what you did
  - [x] Link to relevant issues in GitHub or Jira
  - [x] Link to relevant pull requests, esp. upstream and downstream changes
  - [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed


Resolves #410 