### PR TITLE
Fix plugins.io page content display

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <packaging>hpi</packaging>
 
   <name>Resources AI Chatbot Plugin</name>
-  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin/blob/main/README.md</url>
   <licenses>
     <license>
       <name>MIT License</name>


### PR DESCRIPTION
## Analysis
In Line 59 of [plugins content page](https://github.com/jenkins-infra/plugin-site/blob/main/plugins/plugin-site/src/components/PluginWikiContent.jsx) a fallback case is added if documentation isn't available. 
In multiple commonly used repos, the `pom.xml` has same URL style. 
Found 2 of them while browsing having the newly updated URL.
1. Line 17 of [open-id plugin](https://github.com/jenkinsci/openid-plugin/blob/f1efefbbc8b26f79bdd2ff9ec248acec4527a55d/pom.xml#L17)
2. Line 35 of [acetunix plugin](https://github.com/jenkinsci/acunetix-plugin/blob/3d85ecb065a0c69e138051c0ae3b3341c63170f3/pom.xml#L35)

## Fix
Update the URL to fetch readme.md. 
This might improve the plugins.io page content fetching.

Resolves: #414 