### PR TITLE
fix: prevent KeyError crash in validate_tool_calls when required param is missing (#306)

### DIFF
--- a/chatbot-core/api/tools/utils.py
+++ b/chatbot-core/api/tools/utils.py
@@ -82,15 +82,15 @@ def validate_tool_calls(tool_calls_parsed: list, logger) -> bool:
             if not isinstance(params, dict):
                 logger.warning("Params for tool %s is not a dict.", tool)
                 valid = False
-
-            for param_name, param_type in expected_params.items():
-                if param_name not in params:
-                    logger.warning("Tool: %s: Param %s is not expected.", tool, param_name)
-                    valid = False
-                if not isinstance(params[param_name], param_type):
-                    logger.warning("Tool: %s: Param %s is not of the expected type %s.",
-                                tool, param_name, param_type.__name__)
-                    valid = False
+            else:
+                for param_name, param_type in expected_params.items():
+                    if param_name not in params:
+                        logger.warning("Tool: %s: Param %s is missing.", tool, param_name)
+                        valid = False
+                    elif not isinstance(params[param_name], param_type):
+                        logger.warning("Tool: %s: Param %s is not of the expected type %s.",
+                                    tool, param_name, param_type.__name__)
+                        valid = False
 
     return valid
 

--- a/chatbot-core/tests/unit/tools/test_validate_tool_calls.py
+++ b/chatbot-core/tests/unit/tools/test_validate_tool_calls.py
@@ -1,0 +1,63 @@
+"""Unit tests for api/tools/utils.py – validate_tool_calls."""
+from unittest.mock import MagicMock
+from api.tools.utils import validate_tool_calls
+
+
+class TestValidateToolCalls:
+    """Tests for the validate_tool_calls function."""
+
+    def _make_logger(self):
+        return MagicMock()
+
+    def test_valid_single_tool_call(self):
+        logger = self._make_logger()
+        calls = [{"tool": "search_jenkins_docs", "params": {"query": "test"}}]
+        assert validate_tool_calls(calls, logger) is True
+
+    def test_valid_multiple_tool_calls(self):
+        logger = self._make_logger()
+        calls = [
+            {"tool": "search_jenkins_docs", "params": {"query": "test"}},
+            {"tool": "search_plugin_docs", "params": {"plugin_name": "git", "query": "test"}},
+        ]
+        assert validate_tool_calls(calls, logger) is True
+
+    def test_unknown_tool_name_returns_false(self):
+        logger = self._make_logger()
+        calls = [{"tool": "nonexistent_tool", "params": {}}]
+        assert validate_tool_calls(calls, logger) is False
+        logger.warning.assert_called_once()
+
+    def test_missing_required_param_returns_false_no_crash(self):
+        """Issue #306: must not raise KeyError when a required param is absent."""
+        logger = self._make_logger()
+        calls = [{"tool": "search_jenkins_docs", "params": {"keywords": "test"}}]
+        assert validate_tool_calls(calls, logger) is False
+
+    def test_missing_param_logs_correct_message(self):
+        """Issue #306: warning should say 'is missing', not 'is not expected'."""
+        logger = self._make_logger()
+        calls = [{"tool": "search_jenkins_docs", "params": {}}]
+        validate_tool_calls(calls, logger)
+        warning_msg = logger.warning.call_args[0][0]
+        assert "missing" in warning_msg
+
+    def test_wrong_param_type_returns_false(self):
+        logger = self._make_logger()
+        calls = [{"tool": "search_jenkins_docs", "params": {"query": 123}}]
+        assert validate_tool_calls(calls, logger) is False
+
+    def test_none_params_returns_false(self):
+        logger = self._make_logger()
+        calls = [{"tool": "search_jenkins_docs", "params": None}]
+        assert validate_tool_calls(calls, logger) is False
+
+    def test_empty_tool_calls_list(self):
+        logger = self._make_logger()
+        assert validate_tool_calls([], logger) is True
+
+    def test_missing_multiple_params(self):
+        logger = self._make_logger()
+        calls = [{"tool": "search_plugin_docs", "params": {}}]
+        assert validate_tool_calls(calls, logger) is False
+        assert logger.warning.call_count == 2


### PR DESCRIPTION
## Fixes #306

### Summary

Fix a `KeyError` crash in `validate_tool_calls()` when the LLM omits a required parameter from a generated tool call. Also fix a `TypeError` when `params` is `None`, and correct a misleading warning message.

---

### Background

The agentic retrieval pipeline calls `validate_tool_calls()` to verify that LLM-generated tool calls have valid tool names and correctly typed parameters. When the LLM produces a tool call with a missing required parameter, two defects cause incorrect behavior:

1. **`KeyError` crash** — after confirming a param is absent, the code falls through to `params[param_name]`, raising `KeyError`
2. **`TypeError` crash** — when `params` is `None`, `param_name not in params` raises `TypeError`
3. **Misleading log message** — the warning says `"Param %s is not expected"` when the actual issue is a missing required param

The crash is currently masked by a broad `except KeyError` in `_get_agent_tool_calls()` (`chat_service.py`), which silently falls back to default tool calls. This means validation never returns a clean `False`, noisy tracebacks pollute logs on every affected call, and the misleading warning message confuses debugging.

---

### Changes

#### `api/tools/utils.py`

| Before | After |
|--------|-------|
| Type check ran unconditionally after param-absence check → `KeyError` | Type check gated with `elif` — only runs when param exists |
| Param iteration ran even when `params` was `None` → `TypeError` | Param iteration wrapped in `else` clause guarded by `isinstance(params, dict)` |
| Warning: `"Param %s is not expected"` | Warning: `"Param %s is missing"` |

**Before:**

```python
if not isinstance(params, dict):
    logger.warning("Params for tool %s is not a dict.", tool)
    valid = False

for param_name, param_type in expected_params.items():
    if param_name not in params:
        logger.warning("Tool: %s: Param %s is not expected.", tool, param_name)
        valid = False
    if not isinstance(params[param_name], param_type):  # ← KeyError
        logger.warning("Tool: %s: Param %s is not of the expected type %s.",
                    tool, param_name, param_type.__name__)
        valid = False
```

**After:**

```python
if not isinstance(params, dict):
    logger.warning("Params for tool %s is not a dict.", tool)
    valid = False
else:
    for param_name, param_type in expected_params.items():
        if param_name not in params:
            logger.warning("Tool: %s: Param %s is missing.", tool, param_name)
            valid = False
        elif not isinstance(params[param_name], param_type):
            logger.warning("Tool: %s: Param %s is not of the expected type %s.",
                        tool, param_name, param_type.__name__)
            valid = False
```

---

### Testing

Added 9 unit tests in `tests/unit/tools/test_validate_tool_calls.py`:

| Test | Scenario | Expected |
|------|----------|----------|
| `test_valid_single_tool_call` | Valid call with all required params | `True` |
| `test_valid_multiple_tool_calls` | Multiple valid calls | `True` |
| `test_unknown_tool_name_returns_false` | Tool name not in `TOOL_SIGNATURES` | `False` |
| `test_missing_required_param_returns_false_no_crash` | Required param absent from `params` | `False` (no `KeyError`) |
| `test_missing_param_logs_correct_message` | Required param absent | Warning says `"is missing"` |
| `test_wrong_param_type_returns_false` | Param value wrong type (e.g. `int` instead of `str`) | `False` |
| `test_none_params_returns_false` | `params` is `None` | `False` (no `TypeError`) |
| `test_empty_tool_calls_list` | Empty input list | `True` |
| `test_missing_multiple_params` | Multiple required params absent | `False`, 2 warnings logged |

**Full unit test suite:**

```
244 passed, 3 skipped, 5 warnings in 7.69s
```

> The 3 skipped tests are `test_llama_cpp_provider` tests (require `llama-cpp-python`, not installed). No existing tests were broken by this change.

---

### Checklist

- [x] Branch is `fix/validate-tool-calls-keyerror` (not `main`)
- [x] PR title follows [conventional commit](https://www.conventionalcommits.org/) format
- [x] Description explains the problem, root cause, and fix
- [x] Links to issue: [**#306**](https://github.com/jenkinsci/resources-ai-chatbot-plugin/issues/306)
- [x] Unit tests added and passing (244/244)
- [x] No breaking changes — purely defensive fix
